### PR TITLE
clarify that a context can also be used by sub-devices of devices

### DIFF
--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -81,8 +81,10 @@ params:
       name: phDevices
       desc: |
             [in][optional][range(0, numDevices)] array of device handles which context has visibility.
-            if nullptr, then all devices supported by the driver instance are visible to the context.
-            otherwise, context only has visibility to devices in this array.
+            if nullptr, then all devices and any sub-devices supported by the driver instance are
+            visible to the context.
+            otherwise, the context only has visibility to the devices and any sub-devices of the
+            devices in this array.
     - type: $x_context_handle_t*
       name: phContext
       desc: "[out] pointer to handle of context object created"


### PR DESCRIPTION
fixes #8 

Clarifies that a context can be used by all of the devices and any sub-devices of the devices that were specified when the context was created.

Signed-off-by: Ben Ashbaugh <ben.ashbaugh@intel.com>