### PR TITLE
add an extension for bfloat16 conversions

### DIFF
--- a/scripts/core/EXT_Bfloat16Conversions.rst
+++ b/scripts/core/EXT_Bfloat16Conversions.rst
@@ -1,0 +1,23 @@
+<%
+import re
+from templates import helper as th
+%><%
+    OneApi=tags['$OneApi']
+    x=tags['$x']
+    X=x.upper()
+%>
+:orphan:
+
+.. _ZE_extension_bfloat16_conversions:
+
+================================
+ Bfloat16 Conversions Extension
+================================
+
+API
+----
+
+* Enumerations
+
+
+    * ${x}_bfloat16_conversions_ext_version_t

--- a/scripts/core/SPIRV.rst
+++ b/scripts/core/SPIRV.rst
@@ -665,6 +665,27 @@ include the **LinkOnceODR** linkage type.
 
 %endif
 
+%if ver >= 1.5:
+Bfloat16 Conversions
+--------------------
+
+${OneApi} Level-Zero API environments supporting the extension
+**${X}_extension_bfloat16_conversions** must must accept SPIR-V modules that
+declare use of the ``SPV_INTEL_bloat16_conversion`` extension via
+**OpExtension**.
+
+When use of the ``SPV_INTEL_bloat16_conversion`` extension is declared in the
+module via **OpExtension**, the environment must accept modules that
+declare the **Bfloat16ConversionINTEL** capability.
+
+For the instructions **OpConvertFToBF16INTEL** and **OpConvertBF16ToFINTEL**
+added by the extension:
+
+- Valid types for *Result Type*, *Float Value*, and *Bfloat16 Value* are Scalars
+  and **OpTypeVectors** with 2, 3, 4, 8, or 16 *Component Count* components
+
+%endif
+
 Numerical Compliance
 ====================
 

--- a/scripts/core/bfloat16conversions.yml
+++ b/scripts/core/bfloat16conversions.yml
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2021-2022 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+# See YaML.md for syntax definition
+#
+--- #--------------------------------------------------------------------------
+type: header
+desc: "Intel $OneApi Level-Zero Extension APIs for Bfloat16 Conversions"
+version: "1.5"
+--- #--------------------------------------------------------------------------
+type: macro
+desc: "Bfloat16 Conversions Extension Name"
+version: "1.5"
+name: $X_BFLOAT16_CONVERSIONS_EXT_NAME
+value: '"$X_extension_bfloat16_conversions"'
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Bfloat16 Conversions Extension Version(s)"
+version: "1.5"
+name: $x_bfloat16_conversions_ext_version_t
+etors:
+    - name: "1_0"
+      value: "$X_MAKE_VERSION( 1, 0 )"
+      desc: "version 1.0"

--- a/scripts/core/bfloat16conversions.yml
+++ b/scripts/core/bfloat16conversions.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021-2022 Intel Corporation
+# Copyright (C) 2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #


### PR DESCRIPTION
fixes #14

Adds the ZE_extension_bfloat16_conversions extension.

This extension adds no new APIs but does allow usage of bfloat16 conversion instructions in SPIR-V modules.