### PR TITLE
relax restriction and allow ipc events with timestamps

### DIFF
--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -19,7 +19,9 @@ etors:
     - name: IPC
       desc: "signals and waits may be shared across processes"
     - name: KERNEL_TIMESTAMP
-      desc: "Indicates all events in pool will contain kernel timestamps; cannot be combined with $X_EVENT_POOL_FLAG_IPC"
+      desc:
+            "1.0": "Indicates all events in pool will contain kernel timestamps; cannot be combined with $X_EVENT_POOL_FLAG_IPC"
+            "1.5": "Indicates all events in pool will contain kernel timestamps"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Event pool descriptor"


### PR DESCRIPTION
Fixes #9 

Relaxes the restriction prohibiting IPC events from being used with kernel timestamps.

Note: As-written these changes only apply to v1.5 implementations.  Is that correct, or is this a bugfix that should apply to earlier versions as well?

Signed-off-by: Ben Ashbaugh <ben.ashbaugh@intel.com>