### PR TITLE
Add sub-allocations properties extensions

### DIFF
--- a/scripts/core/EXT_Exp_SubAllocationProperties.rst
+++ b/scripts/core/EXT_Exp_SubAllocationProperties.rst
@@ -1,0 +1,70 @@
+<%
+import re
+from templates import helper as th
+%><%
+    OneApi=tags['$OneApi']
+    x=tags['$x']
+    X=x.upper()
+%>
+:orphan:
+
+.. _ZE_experimental_sub_allocations:
+
+=====================================
+ Sub-Allocation Properties Extension
+=====================================
+
+API
+----
+
+* Enumerations
+
+
+    * ${x}_sub_allocations_exp_version_t
+
+
+* Structures
+
+
+    * ${x}_memory_sub_allocations_exp_properties_t
+
+Sub-Allocation Properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Driver implementations may choose to create a device allocation as a series of sub-allocations. For instance,
+an allocation created against a parent device may be allocated internally as set of N sub-allocations, with
+N being the number of sub-devices associated with the parent device.
+
+The sub-allocation properties extension may be used to get the properties, i.e. base address and size, for
+each of those sub-allocations. The following pseudo-code demonstrates a basic use-case of this extension:
+
+.. parsed-literal::
+
+    ${x}MemAllocDevice(context, &desc, size, alignment, device, &ptr);
+
+    ${x}_memory_sub_allocations_exp_properties_t subAllocationDesc {};
+    uitn32_t numberOfSuballocations = 0;
+    subAllocationDesc.stype = ${X}_STRUCTURE_TYPE_MEMORY_SUB_ALLOCATIONS_EXP_PROPERTIES;
+    subAllocationDesc.pCount = &numberOfSuballocations;
+
+    ${x}_memory_allocation_properties_t memAllocProperties {};
+    memAllocProperties.stype = ${X}_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
+    memAllocProperties.pNext = &subAllocationDesc;
+
+    // Get number of sub-allocations
+    ${x}MemGetAllocProperties(context, ptr, &memAllocProperties, nullptr);
+
+    // if more than 1 sub-allocation, then allocation has been split
+    if (numberOfSuballocations > 1) {
+        std::vector<${x}_sub_allocation_t> subAllocationMemAllocProperties(numberOfSuballocations);
+        subAllocationDesc.pSubAllocations = subAllocationMemAllocProperties.data();
+
+        ${x}MemGetAllocProperties(context, ptr, &memAllocProperties, nullptr);
+
+        // retrieve the properties of each sub-allocation
+        for (auto &subAllocationProperty : subAllocationMemAllocProperties) {
+            void * base = subAllocationProperty.base;
+            size_t size = subAllocationProperty.size;
+        }
+    }
+    ...

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -458,6 +458,10 @@ etors:
       desc: $x_fabric_edge_exp_properties_t 
       version: "1.4"
       value: "0x0002000C"
+    - name: MEMORY_SUB_ALLOCATIONS_EXP_PROPERTIES
+      desc: $x_memory_sub_allocations_exp_properties_t
+      version: "1.5"
+      value: "0x0002000D"
     - name: COMMAND_GRAPH_EXP_DESC
       desc: $x_command_graph_exp_desc_t
       version: "2.0"

--- a/scripts/core/subAllocationsProperties.yml
+++ b/scripts/core/subAllocationsProperties.yml
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+# See YaML.md for syntax definition
+#
+--- #--------------------------------------------------------------------------
+type: header
+desc: "Intel $OneApi Level-Zero Extension for querying sub-allocations properties."
+version: "1.5"
+--- #--------------------------------------------------------------------------
+type: macro
+desc: "Sub-Allocations Properties Extension Name"
+version: "1.5"
+name: $X_SUB_ALLOCATIONS_EXP_NAME
+value: '"$X_experimental_sub_allocations"'
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Sub-Allocations Properties Extension Version(s)"
+version: "1.5"
+name: $x_sub_allocations_exp_version_t
+etors:
+    - name: "1_0"
+      value: "$X_MAKE_VERSION( 1, 0 )"
+      desc: "version 1.0"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Properties returned for a sub-allocation"
+version: "1.5"
+class: $xMem
+name: $x_sub_allocation_t
+members:
+    - type: "void*"
+      name: base
+      desc: "[in,out][optional] base address of the sub-allocation"
+    - type: size_t
+      name: size
+      desc: "[in,out][optional] size of the allocation"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Sub-Allocations Properties"
+version: "1.5"
+class: $xMem
+name: $x_memory_sub_allocations_exp_properties_t
+base: $x_base_properties_t
+members:
+    - type: uint32_t*
+      name: pCount
+      desc: |
+            [in,out] pointer to the number of sub-allocations.
+            if count is zero, then the driver shall update the value with the total number of sub-allocations on which the allocation has been divided.
+            if count is greater than the number of sub-allocations, then the driver shall update the value with the correct number of sub-allocations.
+    - type: "$x_sub_allocation_t*"
+      name: pSubAllocations
+      desc: |
+            [in,out][optional][range(0, *pCount)] array of properties for sub-allocations.
+            if count is less than the number of sub-allocations available, then driver shall only retrieve properties for that number of sub-allocations.
+details:
+    - "This structure may be passed to $xMemGetAllocProperties, via `pNext` member of $x_memory_allocation_properties_t."


### PR DESCRIPTION
Depending on target platform, certain Level Zero drivers may split an L0 allocation into smaller sub-allocations for performance purposes. This extension allows applications to query for the number and size of those sub-allocations.

Signed-off-by: Jaime Arteaga <jaime.a.arteaga.molina@intel.com>