### PR TITLE
separate APIs for initializing and enumerating sysman

### DIFF
--- a/scripts/sysman/PROG.rst
+++ b/scripts/sysman/PROG.rst
@@ -24,7 +24,13 @@ High-level overview
 Environment Variables
 ---------------------
 
+%if ver >= 1.5:
+The System Resource Management library may now be initialized without using environment variables by calling ${s}Init.
+
+For compatibility, the following environment variables may also be enabled during initialization for the respective feature.
+%else:
 The following environment variables are required to be enabled during initialization for the respective feature.
+%endif
 
 ## --validate=off
 +-----------------+-------------------------------------+------------+-----------------------------------------------------------------------------------+
@@ -39,12 +45,51 @@ The following environment variables are required to be enabled during initializa
 Initialization
 --------------
 
+%if ver >= 1.5:
+An application wishing to manage power and performance for devices may
+use the System Resource Management library to enumerate system management
+driver and device handles.
+
+The following pseudo-code demonstrates a basic initialization and device discovery sequence:
+
+.. parsed-literal::
+
+   function main( ... )
+       if (${s}Init(0) != ${X}_RESULT_SUCCESS)
+           output("Can't initialize the API")
+       else
+           # Discover all the drivers
+           uint32_t driversCount = 0
+           ${s}DriverGet(&driversCount, nullptr)
+           ${s}_driver_handle_t* allDrivers = allocate(driversCount * sizeof(${s}_driver_handle_t))
+           ${s}DriverGet(&driversCount, allDrivers)
+
+           ${s}_driver_handle_t hDriver = nullptr
+           for(i = 0 .. driversCount-1)
+               # Discover devices in a driver
+               uint32_t deviceCount = 0
+               ${s}DeviceGet(allDrivers[i], &deviceCount, nullptr)
+
+               ${s}_device_handle_t* hSysmanHandles =
+                   allocate_memory(deviceCount * sizeof(${s}_device_handle_t))
+               ${s}DeviceGet(allDrivers[i], &deviceCount, hSysmanHandles)
+
+               # Use the hSymanHandles to manage the devices
+
+       free_memory(...)
+
+For compatibility, an application may also use the Level0 Core API to
+enumerate through available accelerator devices in the system. For
+each device handle, an application can cast it to a sysman device handle
+to manage the system resources of the device.
+%else:
 An application wishing to manage power and performance for devices first
 needs to use the Level0 Core API to enumerate through available
 accelerator devices in the system and select those of interest.
 
 For each selected device handle, applications can cast it to a
 **Sysman device handle** to manage system resources of the device.
+%endif
 
 .. image:: ../images/tools_sysman_object_hierarchy.png
 

--- a/scripts/sysman/device.yml
+++ b/scripts/sysman/device.yml
@@ -10,6 +10,33 @@ type: header
 desc: "Intel $OneApi Level-Zero Tool APIs for System Resource Management (Sysman) - Device management"
 ordinal: "2"
 --- #--------------------------------------------------------------------------
+type: function
+desc: "Retrieves sysman devices within a sysman driver"
+version: "1.5"
+class: $sDevice
+name: Get
+decl: static
+ordinal: "0"
+details:
+    - "Multiple calls to this function will return identical sysman device handles, in the same order."
+    - "The application may call this function from simultaneous threads."
+    - "The implementation of this function should be lock-free."
+params:
+    - type: $s_driver_handle_t
+      name: hDriver
+      desc: "[in] handle of the sysman driver instance"
+    - type: "uint32_t*"
+      name: pCount
+      desc: |
+            [in,out] pointer to the number of sysman devices.
+            if count is zero, then the driver shall update the value with the total number of sysman devices available.
+            if count is greater than the number of sysman devices available, then the driver shall update the value with the correct number of sysman devices available.
+    - type: "$s_device_handle_t*"
+      name: phDevices
+      desc: |
+            [in,out][optional][range(0, *pCount)] array of handle of sysman devices.
+            if count is less than the number of sysman devices available, then driver shall only retrieve that number of sysman devices.
+--- #--------------------------------------------------------------------------
 type: macro
 desc: "Maximum number of characters in string properties."
 name: $S_STRING_PROPERTY_SIZE

--- a/scripts/sysman/driver.yml
+++ b/scripts/sysman/driver.yml
@@ -27,8 +27,7 @@ name: Init
 decl: static
 ordinal: "0"
 details: 
-    # Note: Using $S_ENABLE_SYSMAN here does not link properly.
-    - "The application must call this function or $xInit with the ZES_ENABLE_SYSMAN environment variable set before calling any other sysman function."
+    - "The application must call this function or $xInit with the $S_ENABLE_SYSMAN environment variable set before calling any other sysman function."
     - "If this function is not called then all other sysman functions will return $X_RESULT_ERROR_UNINITIALIZED."
     - "Only one instance of sysman will be initialized per process."
     - "The application must call this function after forking new processes. Each forked process must call this function."

--- a/scripts/sysman/driver.yml
+++ b/scripts/sysman/driver.yml
@@ -1,0 +1,71 @@
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+# See YaML.md for syntax definition
+#
+--- #--------------------------------------------------------------------------
+type: header
+desc: "Intel $OneApi Level-Zero Tool APIs for System Resource Management (Sysman)"
+ordinal: "1"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Supported sysman initialization flags"
+version: "1.5"
+class: $s
+name: $s_init_flags_t
+etors:
+    - name: PLACEHOLDER
+      desc: "placeholder for future use"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Initialize $OneApi System Resource Management (sysman)"
+version: "1.5"
+class: $s
+name: Init
+decl: static
+ordinal: "0"
+details: 
+    # Note: Using $S_ENABLE_SYSMAN here does not link properly.
+    - "The application must call this function or $xInit with the ZES_ENABLE_SYSMAN environment variable set before calling any other sysman function."
+    - "If this function is not called then all other sysman functions will return $X_RESULT_ERROR_UNINITIALIZED."
+    - "Only one instance of sysman will be initialized per process."
+    - "The application must call this function after forking new processes. Each forked process must call this function."
+    - "The application may call this function from simultaneous threads."
+    - "The implementation of this function must be thread-safe for scenarios where multiple libraries may initialize sysman simultaneously."
+params:
+    - type: $s_init_flags_t
+      name: flags
+      desc: |
+            [in] initialization flags.
+            currently unused, must be 0 (default).
+      init: "0"
+returns:
+    - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Retrieves sysman driver instances"
+version: "1.5"
+class: $sDriver
+name: Get
+decl: static
+ordinal: "0"
+details:
+    - "A sysman driver represents a collection of physical devices."
+    - "Multiple calls to this function will return identical sysman driver handles, in the same order."
+    - "The application may pass nullptr for pDrivers when only querying the number of sysman drivers."
+    - "The application may call this function from simultaneous threads."
+    - "The implementation of this function should be lock-free."
+params:
+    - type: "uint32_t*"
+      name: pCount
+      desc: |
+            [in,out] pointer to the number of sysman driver instances.
+            if count is zero, then the loader shall update the value with the total number of sysman drivers available.
+            if count is greater than the number of sysman drivers available, then the loader shall update the value with the correct number of sysman drivers available.
+    - type: "$s_driver_handle_t*"
+      name: phDrivers
+      desc: |
+            [in,out][optional][range(0, *pCount)] array of sysman driver instance handles.
+            if count is less than the number of sysman drivers available, then the loader shall only retrieve that number of sysman drivers.


### PR DESCRIPTION
This PR has several changes related to #7:

* It adds a `zesInit` function to initialize sysman separate from the `zeInit` function.  It does not require an environment variable.
* It adds separate `zesDriverGet` and `zesDeviceGet` functions to enumerate sysman drivers and devices, rather than enumerating devices via core APIs and casting to sysman device handles.
* After enumerating device handles, sysman can be used exactly as it was before.

I added the APIs and I also updated the programming guide to describe how they are used.

Things we still need to decide (could be fixed in this PR or separately):

* Do we want query functions to determine if a core driver or device handle can be converted to a sysman driver or device handle, e.g. `zesDriverSupported`, or are the separate functions to enumerate sysman drivers and devices sufficient?
* Likewise, do we want a function to convert between a core driver or device handle to a sysman driver or device handle?