### PR TITLE
clarify commands in an immediate command list may execute synchronously

### DIFF
--- a/scripts/core/PROG.rst
+++ b/scripts/core/PROG.rst
@@ -911,7 +911,8 @@ A special type of command list can be used for very low-latency submission usage
 
 - An immediate command list is both a command list and an implicit command queue.
 - An immediate command list is created using a command queue descriptor.
-- Commands submitted to an immediate command list are immediately executed on the device.
+- Commands appended into an immediate command list are immediately executed on the device.
+- Commands appended into an immediate command list may execute synchronously, by blocking until the command is complete.
 - An immediate command list is not required to be closed or reset. However, usage will be honored, and expected behaviors will be followed.
 
 The following pseudo-code demonstrates a basic sequence for creation and usage of immediate command lists:

--- a/scripts/core/cmdlist.yml
+++ b/scripts/core/cmdlist.yml
@@ -83,6 +83,7 @@ ordinal: "0"
 details:
     - "An immediate command list is used for low-latency submission of commands."
     - "An immediate command list creates an implicit command queue."
+    - "Commands appended into an immediate command list may execute synchronously, by blocking until the command is complete."
     - "The command list is created in the 'open' state and never needs to be closed."
     - "The application must only use the command list for the device, or its sub-devices, which was provided during creation."
     - "The application may call this function from simultaneous threads."


### PR DESCRIPTION
This change clarifies that commands appended to an immediate command list may execute synchronously, by blocking until the command is complete.

Signed-off-by: Ben Ashbaugh <ben.ashbaugh@intel.com>