### PR TITLE
Move image view extension to standard

### DIFF
--- a/scripts/core/EXT_Exp_ImageViewPlanar.rst
+++ b/scripts/core/EXT_Exp_ImageViewPlanar.rst
@@ -14,6 +14,10 @@ from templates import helper as th
  Image View Planar Extension
 =============================
 
+%if ver >= 1.5:
+This experimental extension is deprecated and replaced by the ${X}_extension_image_view_planar standard extension.
+%endif
+
 API
 ----
 

--- a/scripts/core/EXT_ImageView.rst
+++ b/scripts/core/EXT_ImageView.rst
@@ -8,15 +8,11 @@ from templates import helper as th
 %>
 :orphan:
 
-.. _ZE_experimental_image_view:
+.. _ZE_extension_image_view:
 
 =========================
  Image View Extension
 =========================
-
-%if ver >= 1.5:
-This experimental extension is deprecated and replaced by the ${X}_extension_image_view standard extension.
-%endif
 
 API
 ----
@@ -24,11 +20,11 @@ API
 * Functions
 
 
-    * ${x}ImageViewCreateExp
+    * ${x}ImageViewCreateExt
 
- 
+
 * Enumerations
 
 
-    * ${x}_image_view_exp_version_t
+    * ${x}_image_view_ext_version_t
 

--- a/scripts/core/EXT_ImageViewPlanar.rst
+++ b/scripts/core/EXT_ImageViewPlanar.rst
@@ -1,0 +1,31 @@
+<%
+import re
+from templates import helper as th
+%><%
+    OneApi=tags['$OneApi']
+    x=tags['$x']
+    X=x.upper()
+%>
+:orphan:
+
+.. _ZE_extension_image_view_planar:
+
+=============================
+ Image View Planar Extension
+=============================
+
+API
+----
+
+* Enumerations
+
+
+    * ${x}_image_view_planar_ext_version_t
+
+
+* Structures
+
+
+    * ${x}_image_view_planar_ext_desc_t
+
+

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -410,6 +410,9 @@ etors:
     - name: DEVICE_IP_VERSION_EXT
       desc: $x_device_ip_version_ext_t
       version: "1.5"
+    - name: IMAGE_VIEW_PLANAR_EXT_DESC
+      desc: $x_image_view_planar_ext_desc_t
+      version: "1.5"
     - name: RELAXED_ALLOCATION_LIMITS_EXP_DESC
       desc: $x_relaxed_allocation_limits_exp_desc_t
       value: "0x00020001"

--- a/scripts/core/imageview.yml
+++ b/scripts/core/imageview.yml
@@ -8,6 +8,62 @@
 --- #--------------------------------------------------------------------------
 type: header
 desc: "Intel $OneApi Level-Zero Extension for supporting image views."
+version: "1.5"
+--- #--------------------------------------------------------------------------
+type: macro
+desc: "Image View Extension Name"
+version: "1.5"
+name: $X_IMAGE_VIEW_EXT_NAME
+value: '"$X_extension_image_view"'
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Image View Extension Version(s)"
+version: "1.5"
+name: $x_image_view_ext_version_t
+etors:
+    - name: "1_0"
+      value: "$X_MAKE_VERSION( 1, 0 )"
+      desc: "version 1.0"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Create image view on the context."
+version: "1.5"
+class: $xImage
+name: ViewCreateExt
+decl: static
+ordinal: "0"
+details:
+    - "The application must only use the image view for the device, or its sub-devices, which was provided during creation."
+    - "The application may call this function from simultaneous threads."
+    - "The implementation of this function must be thread-safe."
+    - "The implementation must support $X_extension_image_view extension."
+    - "Image views are treated as images from the API."
+    - "Image views provide a mechanism to redescribe how an image is interpreted (e.g. different format)."
+    - "Image views become disabled when their corresponding image resource is destroyed."
+    - "Use $xImageDestroy to destroy image view objects."
+analogue:
+    - None
+params:
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_device_handle_t
+      name: hDevice
+      desc: "[in] handle of the device"
+    - type: "const $x_image_desc_t*"
+      name: desc
+      desc: "[in] pointer to image descriptor"
+    - type: "$x_image_handle_t"
+      name: hImage
+      desc: "[in] handle of image object to create view from"
+    - type: "$x_image_handle_t*"
+      name: phImageView
+      desc: "[out] pointer to handle of image object created for view"
+returns:
+    - $X_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT
+--- #--------------------------------------------------------------------------
+type: header
+desc: "Intel $OneApi Level-Zero Extension for supporting image views."
 version: "1.2"
 --- #--------------------------------------------------------------------------
 type: macro
@@ -41,6 +97,7 @@ details:
     - "Image views provide a mechanism to redescribe how an image is interpreted (e.g. different format)."
     - "Image views become disabled when their corresponding image resource is destroyed."
     - "Use $xImageDestroy to destroy image view objects."
+    - "1.5": "Note: This function is deprecated and replaced by $xImageViewCreateExt."
 analogue:
     - None
 params:

--- a/scripts/core/imageviewplanar.yml
+++ b/scripts/core/imageviewplanar.yml
@@ -8,6 +8,36 @@
 --- #--------------------------------------------------------------------------
 type: header
 desc: "Intel $OneApi Level-Zero Extension for supporting image views for planar images."
+version: "1.5"
+--- #--------------------------------------------------------------------------
+type: macro
+desc: "Image View Planar Extension Name"
+version: "1.5"
+name: $X_IMAGE_VIEW_PLANAR_EXT_NAME
+value: '"$X_extension_image_view_planar"'
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Image View Planar Extension Version(s)"
+version: "1.5"
+name: $x_image_view_planar_ext_version_t
+etors:
+    - name: "1_0"
+      value: "$X_MAKE_VERSION( 1, 0 )"
+      desc: "version 1.0"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Image view planar descriptor"
+version: "1.5"
+class: $xImage
+name: $x_image_view_planar_ext_desc_t
+base: $x_base_desc_t
+members:
+    - type: uint32_t
+      name: planeIndex
+      desc: "[in] the 0-based plane index (e.g. NV12 is 0 = Y plane, 1 UV plane)"
+--- #--------------------------------------------------------------------------
+type: header
+desc: "Intel $OneApi Level-Zero Extension for supporting image views for planar images."
 version: "1.2"
 --- #--------------------------------------------------------------------------
 type: macro


### PR DESCRIPTION
This is being used by several customers, and feedback is that it is good to be promoted to standard.

Extension will still be kept to facilitate transition.

Signed-off-by: Jaime Arteaga <jaime.a.arteaga.molina@intel.com>