### PR TITLE
script update: support version-specific details

### DIFF
--- a/scripts/core/driver.yml
+++ b/scripts/core/driver.yml
@@ -39,6 +39,8 @@ details:
       "1.6": "This detail would be valid in version 1.6."
     - "1.0": "This is another detail that is valid in version 1.0."
       "1.2": "This is another detail that is valid in version 1.2."
+    - "1.5": "This detail is only valid in version 1.5."
+    - "1.6": "This detail would only be valid in version 1.6."
 params:
     - type: $x_init_flags_t
       name: flags

--- a/scripts/core/driver.yml
+++ b/scripts/core/driver.yml
@@ -34,6 +34,11 @@ details:
     - "The application must call this function after forking new processes. Each forked process must call this function."
     - "The application may call this function from simultaneous threads."
     - "The implementation of this function must be thread-safe for scenarios where multiple libraries may initialize the driver(s) simultaneously."
+    - "1.0": "This detail is valid in version 1.0."
+      "1.5": "This detail is valid in version 1.5."
+      "1.6": "This detail would be valid in version 1.6."
+    - "1.0": "This is another detail that is valid in version 1.0."
+      "1.2": "This is another detail that is valid in version 1.2."
 params:
     - type: $x_init_flags_t
       name: flags

--- a/scripts/core/driver.yml
+++ b/scripts/core/driver.yml
@@ -34,13 +34,6 @@ details:
     - "The application must call this function after forking new processes. Each forked process must call this function."
     - "The application may call this function from simultaneous threads."
     - "The implementation of this function must be thread-safe for scenarios where multiple libraries may initialize the driver(s) simultaneously."
-    - "1.0": "This detail is valid in version 1.0."
-      "1.5": "This detail is valid in version 1.5."
-      "1.6": "This detail would be valid in version 1.6."
-    - "1.0": "This is another detail that is valid in version 1.0."
-      "1.2": "This is another detail that is valid in version 1.2."
-    - "1.5": "This detail is only valid in version 1.5."
-    - "1.6": "This detail would only be valid in version 1.6."
 params:
     - type: $x_init_flags_t
       name: flags

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -423,6 +423,28 @@ def _filter_version(d, max_ver):
             d['desc'] = desc
         return d
 
+    # Start of new code:
+    def __filter_detail(det):
+        if isinstance(det, dict):
+            detail = None
+            for k, v in det.items():
+                try:
+                    version = float(k)
+                except:
+                    continue
+                if version <= max_ver:
+                    detail = v
+            if detail:
+                return detail
+        return det
+
+    if 'details' in d:
+        flt = []
+        for det in d['details']:
+            flt.append(__filter_detail(det))
+        d['details'] = flt
+    # End of new code.
+
     flt = []
     type = d['type']
     if 'enum' == type:

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -423,7 +423,6 @@ def _filter_version(d, max_ver):
             d['desc'] = desc
         return d
 
-    # Start of new code:
     def __filter_detail(det):
         if isinstance(det, dict):
             detail = None
@@ -444,7 +443,6 @@ def _filter_version(d, max_ver):
             if fd:
                 flt.append(fd)
         d['details'] = flt
-    # End of new code.
 
     flt = []
     type = d['type']

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -431,17 +431,18 @@ def _filter_version(d, max_ver):
                 try:
                     version = float(k)
                 except:
-                    continue
+                    return det
                 if version <= max_ver:
                     detail = v
-            if detail:
-                return detail
+            return detail
         return det
 
     if 'details' in d:
         flt = []
         for det in d['details']:
-            flt.append(__filter_detail(det))
+            fd = __filter_detail(det)
+            if fd:
+                flt.append(fd)
         d['details'] = flt
     # End of new code.
 


### PR DESCRIPTION
This PR adds support for version-specific details, which could be useful for e.g. #12.

The syntax is similar to that for descriptions.  Example:

```yaml
details: 
    - "1.0": "This detail is valid in version 1.0."
      "1.5": "This detail is valid in version 1.5."
      "1.6": "This detail would be valid in version 1.6."
    - "1.0": "This is another detail that is valid in version 1.0."
      "1.2": "This is another detail that is valid in version 1.2."
    - "1.5": "This detail is only valid in version 1.5."
    - "1.6": "This detail would only be valid in version 1.6."

```