### PR TITLE
fix off-by-one error for maximum memory allocation size

### DIFF
--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -115,7 +115,7 @@ base: $x_base_desc_t
 members:
     - type: uint32_t
       name: index
-      desc: "[in] index of the event within the pool; must be less-than the count specified during pool creation"
+      desc: "[in] index of the event within the pool; must be less than the count specified during pool creation"
     - type: $x_event_scope_flags_t
       name: signal
       desc: |

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -100,7 +100,7 @@ params:
       desc: "[in] pointer to host memory allocation descriptor"
     - type: size_t
       name: size
-      desc: "[in] size in bytes to allocate; must be less-than $x_device_properties_t.maxMemAllocSize."
+      desc: "[in] size in bytes to allocate; must be less than or equal to $x_device_properties_t.maxMemAllocSize."
     - type: size_t
       name: alignment
       desc: "[in] minimum alignment in bytes for the allocation; must be a power of two."
@@ -137,7 +137,7 @@ params:
       desc: "[in] pointer to device memory allocation descriptor"
     - type: size_t
       name: size
-      desc: "[in] size in bytes to allocate; must be less-than $x_device_properties_t.maxMemAllocSize."
+      desc: "[in] size in bytes to allocate; must be less than or equal to $x_device_properties_t.maxMemAllocSize."
     - type: size_t
       name: alignment
       desc: "[in] minimum alignment in bytes for the allocation; must be a power of two."
@@ -175,7 +175,7 @@ params:
       desc: "[in] pointer to host memory allocation descriptor"
     - type: size_t
       name: size
-      desc: "[in] size in bytes to allocate; must be less-than $x_device_properties_t.maxMemAllocSize."
+      desc: "[in] size in bytes to allocate; must be less than or equal to $x_device_properties_t.maxMemAllocSize."
     - type: size_t
       name: alignment
       desc: "[in] minimum alignment in bytes for the allocation; must be a power of two."

--- a/scripts/core/module.yml
+++ b/scripts/core/module.yml
@@ -863,7 +863,7 @@ params:
       desc: "[in][range(0, numKernels)] handles of the kernel objects"
     - type: "const uint32_t*"
       name: pCountBuffer
-      desc: "[in] pointer to device memory location that will contain the actual number of kernels to launch; value must be less-than or equal-to numKernels"
+      desc: "[in] pointer to device memory location that will contain the actual number of kernels to launch; value must be less than or equal to numKernels"
     - type: "const $x_group_count_t*"
       name: pLaunchArgumentsBuffer
       desc: "[in][range(0, numKernels)] pointer to device buffer that will contain a contiguous array of thread group launch arguments"


### PR DESCRIPTION
Fixes #42 

We should be able to allocate up to the maximum memory allocation size, not up to the maximum memory allocation size minus one.  Note, this is retroactive to all spec versions (so treated as a spec bugfix), and is not a v1.5-specific addition.

Also removes a few extraneous hyphens in `less-than` and `equal-to`.