### PR TITLE
fix scripts to enable building older spec versions

### DIFF
--- a/scripts/core/PROG.rst
+++ b/scripts/core/PROG.rst
@@ -1096,7 +1096,7 @@ A kernel timestamp event is a special type of event that records device timestam
 %if ver >= 1.1:
        const double timestampFreq = NS_IN_SEC / device_properties.timerResolution;
 %endif
-%if ver < 1.5:
+%if ver < 1.1:
        const uint64_t timestampFreq = device_properties.timerResolution;
 %endif
        const uint64_t timestampMaxValue = ~(-1 << device_properties.kernelTimestampValidBits);

--- a/scripts/core/PROG.rst
+++ b/scripts/core/PROG.rst
@@ -613,7 +613,8 @@ Devices may describe the types of external memory handles they support using ${x
 
 %if ver >= 1.5:
 Importing and exporting external memory is supported for device and host memory allocations and images.
-%else:
+%endif
+%if ver < 1.5:
 Importing and exporting external memory is supported for device memory allocations and images.
 %endif
 
@@ -1094,7 +1095,8 @@ A kernel timestamp event is a special type of event that records device timestam
        // Get timestamp frequency
 %if ver >= 1.1:
        const double timestampFreq = NS_IN_SEC / device_properties.timerResolution;
-%else:
+%endif
+%if ver < 1.5:
        const uint64_t timestampFreq = device_properties.timerResolution;
 %endif
        const uint64_t timestampMaxValue = ~(-1 << device_properties.kernelTimestampValidBits);

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -24,7 +24,7 @@ RE_EXTRACT_NAME     = r"\$\{\w\}\w+"
 RE_EXTRACT_PARAMS   = r"\w+\((.*)\)\;"
 
 RE_VERSION_BEGIN    = r"\%if\s+(ver\s+[\<\=\>]+\s+[-+]?\d*\.\d+|\d+).*"
-RE_VERSION_END      = r"\%endif\s+#\s+.*"
+RE_VERSION_END      = r"\%endif.*"
 
 
 """

--- a/scripts/sysman/PROG.rst
+++ b/scripts/sysman/PROG.rst
@@ -28,7 +28,8 @@ Environment Variables
 The System Resource Management library may now be initialized without using environment variables by calling ${s}Init.
 
 For compatibility, the following environment variables may also be enabled during initialization for the respective feature.
-%else:
+%endif
+%if ver < 1.5:
 The following environment variables are required to be enabled during initialization for the respective feature.
 %endif
 
@@ -82,7 +83,8 @@ For compatibility, an application may also use the Level0 Core API to
 enumerate through available accelerator devices in the system. For
 each device handle, an application can cast it to a sysman device handle
 to manage the system resources of the device.
-%else:
+%endif
+%if ver < 1.5:
 An application wishing to manage power and performance for devices first
 needs to use the Level0 Core API to enumerate through available
 accelerator devices in the system and select those of interest.


### PR DESCRIPTION
Fixes several issues affecting older spec builds:

* The scripts do not handle "else" statements.  Fixed by inverting the "if" condition instead.
* The scripts were not properly handling "endif" statements.  Fixed by correcting the script regular expression.