### PR TITLE
Fix ze_device_properties_t in samples

### DIFF
--- a/scripts/core/PROG.rst
+++ b/scripts/core/PROG.rst
@@ -79,7 +79,8 @@ The following pseudo-code demonstrates a basic initialization and device discove
            ${x}DeviceGet(allDrivers[i], &deviceCount, allDevices);
 
            for(d = 0; d < deviceCount; ++d) {
-               ${x}_device_properties_t device_properties;
+               ${x}_device_properties_t device_properties {};
+               device_properties.stype = ${X}_STRUCTURE_TYPE_DEVICE_PROPERTIES;
                ${x}DeviceGetProperties(allDevices[d], &device_properties);
 
                if(${X}_DEVICE_TYPE_GPU == device_properties.type) {
@@ -1772,7 +1773,8 @@ or sub-device using ${x}DeviceGetProperties.
        ${x}_device_handle_t hSubdevice = allSubDevices[2];
 
        // Query sub-device properties.
-       ${x}_device_properties_t subdeviceProps;
+       ${x}_device_properties_t subdeviceProps {};
+       subDeviceProps.stype = ${X}_STRUCTURE_TYPE_DEVICE_PROPERTIES;
        ${x}DeviceGetProperties(hSubdevice, &subdeviceProps);
 
        assert(subdeviceProps.flags & ${X}_DEVICE_PROPERTY_FLAG_SUBDEVICE); // Ensure that we have a handle to a sub-device.

--- a/scripts/sysman/PROG.rst
+++ b/scripts/sysman/PROG.rst
@@ -123,7 +123,8 @@ system and create Sysman handles for them:
                ${x}DeviceGet(allDrivers[i], &deviceCount, allDevices)
 
                for(devIndex = 0 .. deviceCount-1)
-                   ${x}_device_properties_t device_properties
+                   ${x}_device_properties_t device_properties {}
+                   device_properties.stype = ${X}_STRUCTURE_TYPE_DEVICE_PROPERTIES
                    ${x}DeviceGetProperties(allDevices[devIndex], &device_properties)
                    if(${X}_DEVICE_TYPE_GPU != device_properties.type)
                        next
@@ -516,7 +517,8 @@ device:
 .. parsed-literal::
 
   function ShowDeviceInfo(${s}_device_handle_t hSysmanDevice)
-      ${s}_device_properties_t devProps
+      ${s}_device_properties_t devProps {}
+      devProps.stype = ${X}_STRUCTURE_TYPE_DEVICE_PROPERTIES
       ${s}_device_state_t devState
       if (${s}DeviceGetProperties(hSysmanDevice, &devProps) == ${X}_RESULT_SUCCESS)
           output("    UUID:           %s", devProps.core.uuid.id)

--- a/scripts/tools/PROG.rst
+++ b/scripts/tools/PROG.rst
@@ -760,7 +760,8 @@ The total number of threads on a device can be computed using device properties 
 
 .. parsed-literal::
 
-    ${x}_device_properties_t properties;
+    ${x}_device_properties_t properties {};
+    properties.stype = ${X}_STRUCTURE_TYPE_DEVICE_PROPERTIES;
     uint64_t num_threads;
 
     ${x}DeviceGetProperties(hDevice, &properties);


### PR DESCRIPTION
Correct initialize ze_device_properties_t to zero and set stype properly. This way samples show how to initialize these structs to avoid driver implementations to misread garbage values in pNext.

Signed-off-by: Jaime Arteaga <jaime.a.arteaga.molina@intel.com>