### PR TITLE
Clarify intended interpretation of 32-bit device id.

### DIFF
--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -128,7 +128,9 @@ members:
       desc: "[out] vendor id from PCI configuration"
     - type: uint32_t
       name: deviceId
-      desc: "[out] device id from PCI configuration"
+      desc: |
+            [out] device id from PCI configuration
+            Note, the least-significant 16-bits contain the device id.
     - type: $x_device_property_flags_t
       name: flags
       desc: "[out] 0 (none) or a valid combination of $x_device_property_flag_t"

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -130,7 +130,7 @@ members:
       name: deviceId
       desc: |
             [out] device id from PCI configuration
-            Note, the least-significant 16-bits contain the device id.
+            Note, the device id uses little-endian format.
     - type: $x_device_property_flags_t
       name: flags
       desc: "[out] 0 (none) or a valid combination of $x_device_property_flag_t"


### PR DESCRIPTION
Resolves #54

Signed-off-by: Will Damon \<will.damon@intel.com\>