### PR TITLE
Add an extension to get the kernel max group size properties.

### DIFF
--- a/scripts/core/EXT_KernelMaxGroupSizeProperties.rst
+++ b/scripts/core/EXT_KernelMaxGroupSizeProperties.rst
@@ -1,0 +1,31 @@
+<%
+import re
+from templates import helper as th
+%><%
+    OneApi=tags['$OneApi']
+    x=tags['$x']
+    X=x.upper()
+%>
+:orphan:
+
+.. _ZE_extension_kernel_max_group_size_properties:
+
+============================================
+ Kernel Max Group Size Properties Extension
+============================================
+
+API
+----
+
+* Enumerations
+
+
+    * ${x}_kernel_max_group_size_properties_ext_version_t
+
+
+* Structures
+
+
+    * ${x}_kernel_max_group_size_properties_ext_t
+
+

--- a/scripts/core/kernelMaxGroupSizeProperties.yml
+++ b/scripts/core/kernelMaxGroupSizeProperties.yml
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2021-2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+# See YaML.md for syntax definition
+#
+--- #--------------------------------------------------------------------------
+type: header
+desc: "Intel $OneApi Level-Zero Extension for querying kernel max group size properties."
+version: "1.5"
+--- #--------------------------------------------------------------------------
+type: macro
+desc: "Kernel Max Group Size Properties Extension Name"
+version: "1.5"
+name: $X_KERNEL_MAX_GROUP_SIZE_PROPERTIES_EXT_NAME
+value: '"$X_extension_kernel_max_group_size_properties"'
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Kernel Max Group Size Properties Extension Version(s)"
+version: "1.5"
+name: $x_kernel_max_group_size_properties_ext_version_t
+etors:
+    - name: "1_0"
+      value: "$X_MAKE_VERSION( 1, 0 )"
+      desc: "version 1.0"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Additional kernel max group size properties"
+version: "1.5"
+class: $xKernel
+name: $x_kernel_max_group_size_properties_ext_t
+base: $x_base_properties_t
+members:
+    - type: uint32_t
+      name: maxGroupSize
+      desc: "[out] maximum group size that can be used to execute the kernel. This value may be less than or equal to the `maxTotalGroupSize` member of $x_device_compute_properties_t."
+details:
+    - "This structure may be passed to $xKernelGetProperties, via the `pNext` member of $x_kernel_properties_t, to query additional kernel max group size properties."


### PR DESCRIPTION
Summary:
This extension provides the user with the ability to query the maximum group size that can be used to execute the kernel on the device. The implementation uses the resource requirements of the kernel (register usage, etc.) to determine what this group size should be.

Notes:
- This value may vary from one kernel to another as well as one device to another.
- This value will be less than or equal to `ze_device_compute_properties_t::maxTotalGroupSize`.

Resolves #28

Signed-off-by: Will Damon <wdamon@intel.com>