### PR TITLE
Add version 1.5 to GlobalTimestamps ext

### DIFF
--- a/scripts/tools/GlobalTimestamps.yml
+++ b/scripts/tools/GlobalTimestamps.yml
@@ -44,6 +44,7 @@ details:
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Returns metric timestamps synchronized with global device timestamps, optionally synchronized with host"
+version: "1.5"
 class: $tMetricGroup
 name: GetGlobalTimestampsExp
 decl: static


### PR DESCRIPTION
version tag ensures DDI tables maintain proper ordering

Signed-off-by: Brandon Yates <brandon.yates@intel.com>