### PR TITLE
Add zeDriverGetLastResultString

### DIFF
--- a/scripts/core/driver.yml
+++ b/scripts/core/driver.yml
@@ -273,15 +273,15 @@ members:
       desc: "[in] handle of the driver instance"
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Retrieves a message associated with the last error code returned by the driver in the current thread."
+desc: "Retrieves a string describing the last error code returned by the driver in the current thread."
 version: "1.6"
 class: $xDriver
-name: GetLastErrorString
+name: GetLastErrorDescription
 details:
     - "String returned is thread local."
     - "String is only updated on calls returning an error, i.e., not on calls returning $X_RESULT_SUCCESS."
     - "String may be empty if driver considers error code is already explicit enough to describe cause."
-    - "Memory pointed to by ppString is owned by driver."
+    - "Memory pointed to by ppString is owned by the driver."
     - "String returned is null-terminated."
 params:
     - type: $x_driver_handle_t
@@ -289,4 +289,4 @@ params:
       desc: "[in] handle of the driver instance"
     - type: "const char**"
       name: ppString
-      desc: "[in,out] pointer to an null-terminated array of characters containing message associated with the last call."
+      desc: "[in,out] pointer to a null-terminated array of characters describing cause of error."

--- a/scripts/core/driver.yml
+++ b/scripts/core/driver.yml
@@ -291,6 +291,3 @@ params:
     - type: "const char**"
       name: ppString
       desc: "[in,out] pointer to an array of characters containing message associated with the last call."
-    - type: "size_t*"
-      name: pSize
-      desc: "[in,out][optional] size of message string pointed by ppString."

--- a/scripts/core/driver.yml
+++ b/scripts/core/driver.yml
@@ -271,3 +271,26 @@ members:
     - type: $x_driver_handle_t
       name: handle
       desc: "[in] handle of the driver instance"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Retrieves a message associated with the returned code of the last call made."
+version: "1.6"
+class: $xDriver
+name: GetLastResultString
+details:
+    - "String returned is thread local."
+    - |
+       String may be empty if last call returned $X_RESULT_SUCCESS or if driver
+       determines that error code is already explicit enough to convey error cause.
+    - "Memory pointed by ppString is owned by driver."
+    - "String returned is null-terminated."
+params:
+    - type: $x_driver_handle_t
+      name: hDriver
+      desc: "[in] handle of the driver instance"
+    - type: "const char**"
+      name: ppString
+      desc: "[in,out] pointer to an array of characters containing message associated with the last call."
+    - type: "size_t*"
+      name: pSize
+      desc: "[in,out][optional] size of message string pointed by ppString."

--- a/scripts/core/driver.yml
+++ b/scripts/core/driver.yml
@@ -273,16 +273,15 @@ members:
       desc: "[in] handle of the driver instance"
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Retrieves a message associated with the returned code of the last call made."
+desc: "Retrieves a message associated with the last error code returned by the driver in the current thread."
 version: "1.6"
 class: $xDriver
-name: GetLastResultString
+name: GetLastErrorString
 details:
     - "String returned is thread local."
-    - |
-       String may be empty if last call returned $X_RESULT_SUCCESS or if driver
-       determines that error code is already explicit enough to convey error cause.
-    - "Memory pointed by ppString is owned by driver."
+    - "String is only updated on calls returning an error, i.e., not on calls returning $X_RESULT_SUCCESS."
+    - "String may be empty if driver considers error code is already explicit enough to describe cause."
+    - "Memory pointed to by ppString is owned by driver."
     - "String returned is null-terminated."
 params:
     - type: $x_driver_handle_t
@@ -290,4 +289,4 @@ params:
       desc: "[in] handle of the driver instance"
     - type: "const char**"
       name: ppString
-      desc: "[in,out] pointer to an array of characters containing message associated with the last call."
+      desc: "[in,out] pointer to an null-terminated array of characters containing message associated with the last call."


### PR DESCRIPTION
This function retrieves a message associated with the returned code of the last call made.

Resolves: #61