### PR TITLE
Promote zetMetricGroupCalculateMultipleMetricValuesExp to standard

### DIFF
--- a/scripts/tools/PROG.rst
+++ b/scripts/tools/PROG.rst
@@ -589,23 +589,22 @@ Sample below shows how to calculate and process multiple metric values.
        // Example showing how to process the metric values
 
        // Setup
-       uint32_t metricCount = 0;
+       uint32_t metricCountInMetricGroup= 0;
        ${t}MetricGet(hMetricGroup, &metricCount, nullptr);
 
-       ${t}_metric_handle_t* phMetrics = malloc(metricCount * sizeof(${t}_metric_handle_t));
+       ${t}_metric_handle_t* phMetrics = malloc(metricCountInMetricGroup* sizeof(${t}_metric_handle_t));
        ${t}MetricGet(hMetricGroup, &metricCount, phMetrics);
 
        // Loop over the collected metrics
        uint32_t startIndex = 0;
        for (uint32_t setIndex = 0; setIndex < setCount; setIndex++) {
 
-           // Processing each metric data is the same as for the single
-           // calculate metric values
-           const uint32_t metricCountForDataIndex = metricCountPerSet[setIndex];
-           const uint32_t reportCount = metricCountForDataIndex / metricCount;
+           // Process each metric value for every report collected
+           const uint32_t metricsCountInSet= metricCountPerSet[setIndex];
+           const uint32_t reportCount = metricsCountInSet/ metricCount;
            for (uint32_t report = 0; report < reportCount; report++) {
-               for (uint32_t metric = 0; metric < metricCount ; metric++) {
-                   const size_t metricIndex = report * metricCount + metric;
+               for (uint32_t metric = 0; metric < metricCountInMetricGroup; metric++) {
+                   const size_t metricIndex = report * metricCountInMetricGroup+ metric;
                    process_metric_value(metricValues[startIndex + metricIndex]));
                }
            }

--- a/scripts/tools/PROG.rst
+++ b/scripts/tools/PROG.rst
@@ -576,12 +576,12 @@ Sample below shows how to calculate and process multiple metric values.
 
 .. parsed-literal::
 
-       // Get data count and total metric count
+       // Get metrics set count and total metrics count
        uint32_t setCount = 0;
        uint32_t metricValueCount = 0;
        ${t}MetricGroupCalculateMultipleMetricValues(hMetricGroup, type, rawDataSize, pRawData, &setCount, &metricValueCount, nullptr, nullptr);
 
-       // Get metric counts and metric values
+       // Get the metrics count per set and metrics values
        std::vector<uint32_t> metricCountPerSet(setCount);
        std::vector<${t}_typed_value_t> metricValues(metricValueCount);
        ${t}MetricGroupCalculateMultipleMetricValues(hMetricGroup, type, rawDataSize, pRawData, &setCount, &metricValueCount, metricCountPerSet.data(), metricValues.data());
@@ -595,13 +595,13 @@ Sample below shows how to calculate and process multiple metric values.
        ${t}_metric_handle_t* phMetrics = malloc(metricCount * sizeof(${t}_metric_handle_t));
        ${t}MetricGet(hMetricGroup, &metricCount, phMetrics);
 
-       // This loop over metric data is new for this extension
+       // Loop over the collected metrics
        uint32_t startIndex = 0;
-       for (uint32_t dataIndex = 0; dataIndex < setCount; dataIndex++) {
+       for (uint32_t setIndex = 0; setIndex < setCount; setIndex++) {
 
            // Processing each metric data is the same as for the single
            // calculate metric values
-           const uint32_t metricCountForDataIndex = metricCountPerSet[dataIndex];
+           const uint32_t metricCountForDataIndex = metricCountPerSet[setIndex];
            const uint32_t reportCount = metricCountForDataIndex / metricCount;
            for (uint32_t report = 0; report < reportCount; report++) {
                for (uint32_t metric = 0; metric < metricCount ; metric++) {

--- a/scripts/tools/PROG.rst
+++ b/scripts/tools/PROG.rst
@@ -568,6 +568,53 @@ The following pseudo-code demonstrates a basic sequence for metric calculation a
            free(phMetrics);
        }
 
+Calculating Multiple Metrics
+-----------
+
+${t}MetricGroupCalculateMultipleMetricValues can be used to calculate one or more sets of metric values from raw data.
+Sample below shows how to calculate and process multiple metric values.
+
+.. parsed-literal::
+
+       // Get data count and total metric count
+       uint32_t setCount = 0;
+       uint32_t metricValueCount = 0;
+       ${t}MetricGroupCalculateMultipleMetricValues(hMetricGroup, type, rawDataSize, pRawData, &setCount, &metricValueCount, nullptr, nullptr);
+
+       // Get metric counts and metric values
+       std::vector<uint32_t> metricCountPerSet(setCount);
+       std::vector<${t}_typed_value_t> metricValues(metricValueCount);
+       ${t}MetricGroupCalculateMultipleMetricValues(hMetricGroup, type, rawDataSize, pRawData, &setCount, &metricValueCount, metricCountPerSet.data(), metricValues.data());
+
+       // Example showing how to process the metric values
+
+       // Setup
+       uint32_t metricCount = 0;
+       ${t}MetricGet(hMetricGroup, &metricCount, nullptr);
+
+       ${t}_metric_handle_t* phMetrics = malloc(metricCount * sizeof(${t}_metric_handle_t));
+       ${t}MetricGet(hMetricGroup, &metricCount, phMetrics);
+
+       // This loop over metric data is new for this extension
+       uint32_t startIndex = 0;
+       for (uint32_t dataIndex = 0; dataIndex < setCount; dataIndex++) {
+
+           // Processing each metric data is the same as for the single
+           // calculate metric values
+           const uint32_t metricCountForDataIndex = metricCountPerSet[dataIndex];
+           const uint32_t reportCount = metricCountForDataIndex / metricCount;
+           for (uint32_t report = 0; report < reportCount; report++) {
+               for (uint32_t metric = 0; metric < metricCount ; metric++) {
+                   const size_t metricIndex = report * metricCount + metric;
+                   process_metric_value(metricValues[startIndex + metricIndex]));
+               }
+           }
+
+           startIndex += metricCountForDataIndex;
+       }
+       assert(startIndex == metricValueCount);
+
+
 
 Program Instrumentation
 =======================

--- a/scripts/tools/metric.yml
+++ b/scripts/tools/metric.yml
@@ -165,6 +165,7 @@ class: $tMetricGroup
 name: CalculateMultipleMetricValues
 decl: static
 details:
+    - "Application must call firstly pSetCount and pMetricValueCount to know the size to allocate for pMetricCountPerSet and pMetricValues, respectively."
     - "This function calculates more than one set of metric values from a single data buffer.  There may be one set of metric values for each sub-device, for example."
     - "Each set of metric values may consist of a different number of metric values, returned as the metric value count."
     - "All metric values are calculated into a single buffer; use the metric counts to determine which metric values belong to which set."
@@ -185,25 +186,29 @@ params:
     - type: uint32_t*
       name: pSetCount
       desc: |
-            [in,out] pointer to number of metric sets.
+            [in,out][optional] pointer to number of metric sets.
             if *pSetCount is zero, then the driver shall update the value with the total number of metric sets to be calculated.
             if *pSetCount is greater than the number available in the raw data buffer, then the driver shall update the value with the actual number of metric sets to be calculated.
-            if *pSetCount is is less than the number available in the raw data buffer, then the driver shall calculate the metrics for up to that number of sub-devices.
+            if *pSetCount is less than the number of sets available, then driver shall only calculate that number of sets.
     - type: uint32_t*
-      name: pTotalMetricValueCount
+      name: pMetricValueCount
       desc: |
-            [in,out] pointer to number of the total number of metric values calculated, for all metric sets.
-            if *pSetCount is zero, then the driver shall update the value with the total number of metric values to be calculated.
-            if *pSetCount is greater than the number available in the raw data buffer, then the driver shall update the value with the actual number of metric values to be calculated.
+            [in,out][optional] pointer to the total number of metric values calculated, it is the sum of all elements in pMetricCountPerSet array.
+            if *pMetricValueCount is zero, then the driver shall update the value with the total number of metric values to be calculated.
+            if *pMetricValueCount is greater than the number available in the raw data buffer, then the driver shall update the value with the actual number of metric values to be calculated.
     - type: uint32_t*
-      name: pMetricCounts
+      name: pMetricCountPerSet
       desc: |
             [in,out][optional][range(0, *pSetCount)] buffer of metric counts per metric set.
+            Driver shall update the value with the number of metric values calculated for that set.
+            If count for a given set is greater than the number of metric values available in the raw data buffer in that set, then the driver
+            shall update the value with the actual number of metric values to be calculated for that set.
+            if count for a given set is less than the number of metric values available in the raw data buffer in that set, then driver shall
+            only calculate that number of metric values for that set.
     - type: "$t_typed_value_t*"
       name: pMetricValues
       desc: |
-            [in,out][optional][range(0, *pTotalMetricValueCount)] buffer of calculated metrics.
-            if *pSetCount is less than the number available in the raw data buffer, then driver shall only calculate that number of metric values.
+            [in,out][optional][range(0, *pMetricValueCount)] buffer of calculated metrics.
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves metric from a metric group."

--- a/scripts/tools/metric.yml
+++ b/scripts/tools/metric.yml
@@ -165,7 +165,7 @@ class: $tMetricGroup
 name: CalculateMultipleMetricValues
 decl: static
 details:
-    - "Application must call firstly pSetCount and pMetricValueCount to know the size to allocate for pMetricCountPerSet and pMetricValues, respectively."
+    - "Application must query the values of pSetCount and pMetricValueCount to know the sizes to allocate for pMetricCountPerSet and pMetricValues, respectively."
     - "This function calculates more than one set of metric values from a single data buffer.  There may be one set of metric values for each sub-device, for example."
     - "Each set of metric values may consist of a different number of metric values, returned as the metric value count."
     - "All metric values are calculated into a single buffer; use the metric counts to determine which metric values belong to which set."
@@ -202,9 +202,9 @@ params:
             [in,out][optional][range(0, *pSetCount)] buffer of metric counts per metric set.
             Driver shall update the value with the number of metric values calculated for that set.
             If count for a given set is greater than the number of metric values available in the raw data buffer in that set, then the driver
-            shall update the value with the actual number of metric values to be calculated for that set.
-            if count for a given set is less than the number of metric values available in the raw data buffer in that set, then driver shall
-            only calculate that number of metric values for that set.
+            shall update the value with the actual number of metric values calculated for that set.
+            If count for a given set is less than the number of metric values available in the raw data buffer in that set (count must be
+            multiple of the number of metrics in the metric group), then driver shall only calculate that number of metric values for that set.
     - type: "$t_typed_value_t*"
       name: pMetricValues
       desc: |

--- a/scripts/tools/metric.yml
+++ b/scripts/tools/metric.yml
@@ -131,6 +131,7 @@ class: $tMetricGroup
 name: CalculateMetricValues
 decl: static
 details:
+    - "1.6": "Note: This function is deprecated and replaced by $tMetricGroupCalculateMultipleMetricValues."
     - "The application may call this function from simultaneous threads."
 params:
     - type: "$t_metric_group_handle_t"
@@ -156,6 +157,53 @@ params:
       desc: |
             [in,out][optional][range(0, *pMetricValueCount)] buffer of calculated metrics.
             if count is less than the number available in the raw data buffer, then driver shall only calculate that number of metric values.
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Calculate one or more sets of metric values from raw data."
+version: "1.6"
+class: $tMetricGroup
+name: CalculateMultipleMetricValues
+decl: static
+details:
+    - "This function calculates more than one set of metric values from a single data buffer.  There may be one set of metric values for each sub-device, for example."
+    - "Each set of metric values may consist of a different number of metric values, returned as the metric value count."
+    - "All metric values are calculated into a single buffer; use the metric counts to determine which metric values belong to which set."
+    - "The application may call this function from simultaneous threads."
+params:
+    - type: "$t_metric_group_handle_t"
+      name: hMetricGroup
+      desc: "[in] handle of the metric group"
+    - type: "$t_metric_group_calculation_type_t"
+      name: type
+      desc: "[in] calculation type to be applied on raw data"
+    - type: size_t
+      name: rawDataSize
+      desc: "[in] size in bytes of raw data buffer"
+    - type: "const uint8_t*"
+      name: pRawData
+      desc: "[in][range(0, rawDataSize)] buffer of raw data to calculate"
+    - type: uint32_t*
+      name: pSetCount
+      desc: |
+            [in,out] pointer to number of metric sets.
+            if *pSetCount is zero, then the driver shall update the value with the total number of metric sets to be calculated.
+            if *pSetCount is greater than the number available in the raw data buffer, then the driver shall update the value with the actual number of metric sets to be calculated.
+            if *pSetCount is is less than the number available in the raw data buffer, then the driver shall calculate the metrics for up to that number of sub-devices.
+    - type: uint32_t*
+      name: pTotalMetricValueCount
+      desc: |
+            [in,out] pointer to number of the total number of metric values calculated, for all metric sets.
+            if *pSetCount is zero, then the driver shall update the value with the total number of metric values to be calculated.
+            if *pSetCount is greater than the number available in the raw data buffer, then the driver shall update the value with the actual number of metric values to be calculated.
+    - type: uint32_t*
+      name: pMetricCounts
+      desc: |
+            [in,out][optional][range(0, *pSetCount)] buffer of metric counts per metric set.
+    - type: "$t_typed_value_t*"
+      name: pMetricValues
+      desc: |
+            [in,out][optional][range(0, *pTotalMetricValueCount)] buffer of calculated metrics.
+            if *pSetCount is less than the number available in the raw data buffer, then driver shall only calculate that number of metric values.
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves metric from a metric group."

--- a/scripts/tools/multiMetricValues.yml
+++ b/scripts/tools/multiMetricValues.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021-2022 Intel Corporation
+# Copyright (C) 2021-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #
@@ -32,6 +32,7 @@ class: $tMetricGroup
 name: CalculateMultipleMetricValuesExp
 decl: static
 details:
+    - "1.6": "Note: This extension is deprecated and has now been promoted to $tMetricGroupCalculateMultipleMetricValues. It is expected to be removed on next minor version update."
     - "This function is similar to $tMetricGroupCalculateMetricValues except it may calculate more than one set of metric values from a single data buffer.  There may be one set of metric values for each sub-device, for example."
     - "Each set of metric values may consist of a different number of metric values, returned as the metric value count."
     - "All metric values are calculated into a single buffer; use the metric counts to determine which metric values belong to which set."


### PR DESCRIPTION
zetMetricGroupCalculateMultipleMetricValuesExp is kept and marked as deprecated to allow for a smooth transtion on applications. zetMetricGroupCalculateMultipleMetricValuesExp will be removed on next minor version.

zetMetricGroupCalculateMetricValues is also marked as deprecated, as zetMetricGroupCalculateMultipleMetricValues provides better functionality. zetMetricGroupCalculateMetricValues will be kept until next major revision to avoid breaking backward compatibility.

Resolves: #84