### PR TITLE
Revert RAS Category and Fabric API commits (#35, #83)

### DIFF
--- a/scripts/sysman/common.yml
+++ b/scripts/sysman/common.yml
@@ -196,9 +196,6 @@ etors:
     - name: OVERCLOCK_PROPERTIES
       desc: $s_overclock_properties_t
       version: "1.5"
-    - name: FABRIC_PORT_ERROR_COUNTERS
-      desc: $s_fabric_port_error_counters_t
-      version: "1.5"
 --- #-------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/sysman/fabric.yml
+++ b/scripts/sysman/fabric.yml
@@ -185,26 +185,6 @@ members:
       name: "txCounter"
       desc: "[out] Monotonic counter for the number of bytes transmitted (sum of all lanes). This includes all protocol overhead, not only the GPU traffic."
 --- #--------------------------------------------------------------------------
-type: struct
-desc: "Fabric Port Error Counters"
-class: $sFabricPort
-name: $s_fabric_port_error_counters_t
-base: $s_base_properties_t
-version: "1.5"
-members:
-    - type: uint64_t
-      name: "linkFailureCount"
-      desc: "[out] Link Failure Error Count"
-    - type: uint64_t
-      name: "fwCommErrorCount"
-      desc: "[out] Firmware Communication Error Count"
-    - type: uint64_t
-      name: "fwErrorCount"
-      desc: "[out] Firmware reported Error Count"
-    - type: uint64_t
-      name: "linkDegradeCount"
-      desc: "[out] Link Degrade Error Count"
---- #--------------------------------------------------------------------------
 type: function
 desc: "Get handle of Fabric ports in a device"
 class: $sDevice
@@ -320,25 +300,6 @@ params:
     - type: $s_fabric_port_throughput_t*
       name: pThroughput
       desc: "[in,out] Will contain the Fabric port throughput counters."
-returns:
-    - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
-        - "User does not have permissions to query this telemetry."
---- #--------------------------------------------------------------------------
-type: function
-desc: "Get Fabric Port Error Counters"
-class: $sFabricPort
-name: GetFabricErrorCounters
-version: "1.5"
-details:
-    - "The application may call this function from simultaneous threads."
-    - "The implementation of this function should be lock-free."
-params:
-    - type: $s_fabric_port_handle_t
-      name: hPort
-      desc: "[in] Handle for the component."
-    - type: $s_fabric_port_error_counters_t*
-      name: pErrors
-      desc: "[in,out] Will contain the Fabric port Error counters."
 returns:
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to query this telemetry."

--- a/scripts/sysman/ras.yml
+++ b/scripts/sysman/ras.yml
@@ -40,20 +40,11 @@ etors:
       desc: "The number of errors that have occurred in caches (L1/L3/register file/shared local memory/sampler)"
     - name: DISPLAY_ERRORS
       desc: "The number of errors that have occurred in the display"
-    - name: MEMORY_ERRORS
-      desc: "The number of errors that have occurred in Memory"
-      version: "1.5"
-    - name: SCALE_ERRORS
-      desc: "The number of errors that have occurred in Scale Fabric"
-      version: "1.5"
-    - name: L3FABRIC_ERRORS
-      desc: "The number of errors that have occurred in L3 Fabric"
-      version: "1.5"
 --- #--------------------------------------------------------------------------
 type: macro
 desc: "The maximum number of categories"
 name: $S_MAX_RAS_ERROR_CATEGORY_COUNT
-value: "10"
+value: "7"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "RAS properties"


### PR DESCRIPTION
This reverts commits:
  - 7de96547c9b3bc190606eb0a3327e465e6c52459
  - 5ced682e98bf10002d2c3e519373a312f883dadd

...due to a binary incompatibility regression.