### PR TITLE
Misc. formatting fixes.

### DIFF
--- a/scripts/Doxyfile
+++ b/scripts/Doxyfile
@@ -99,7 +99,7 @@ OUTPUT_LANGUAGE        = English
 # Possible values are: None, LTR, RTL and Context.
 # The default value is: None.
 
-OUTPUT_TEXT_DIRECTION  = None
+# OUTPUT_TEXT_DIRECTION  = None
 
 # If the BRIEF_MEMBER_DESC tag is set to YES, doxygen will include brief member
 # descriptions after the members that are listed in the file and class
@@ -1054,7 +1054,7 @@ VERBATIM_HEADERS       = NO
 # generated with the -Duse_libclang=ON option for CMake.
 # The default value is: NO.
 
-CLANG_ASSISTED_PARSING = NO
+# CLANG_ASSISTED_PARSING = NO
 
 # If clang assisted parsing is enabled you can provide the compiler with command
 # line options that you would normally use when invoking the compiler. Note that
@@ -1062,7 +1062,7 @@ CLANG_ASSISTED_PARSING = NO
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          =
+# CLANG_OPTIONS          =
 
 # If clang assisted parsing is enabled you can provide the clang parser with the
 # path to the compilation database (see:
@@ -1072,7 +1072,7 @@ CLANG_OPTIONS          =
 # Note: The availability of this option depends on whether or not doxygen was
 # generated with the -Duse_libclang=ON option for CMake.
 
-CLANG_DATABASE_PATH    =
+# CLANG_DATABASE_PATH    =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
@@ -1090,7 +1090,7 @@ ALPHABETICAL_INDEX     = YES
 # Minimum value: 1, maximum value: 20, default value: 5.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-COLS_IN_ALPHA_INDEX    = 5
+# COLS_IN_ALPHA_INDEX    = 5
 
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag
@@ -1518,7 +1518,7 @@ FORMULA_FONTSIZE       = 10
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-FORMULA_TRANSPARENT    = YES
+# FORMULA_TRANSPARENT    = YES
 
 # Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
 # https://www.mathjax.org) which uses client side Javascript for the rendering
@@ -1838,7 +1838,7 @@ LATEX_HIDE_INDICES     = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_SOURCE_CODE      = NO
+# LATEX_SOURCE_CODE      = NO
 
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
@@ -1928,7 +1928,7 @@ RTF_EXTENSIONS_FILE    =
 # The default value is: NO.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_SOURCE_CODE        = NO
+# RTF_SOURCE_CODE        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the man page output
@@ -2033,7 +2033,7 @@ DOCBOOK_OUTPUT         = docbook
 # The default value is: NO.
 # This tag requires that the tag GENERATE_DOCBOOK is set to YES.
 
-DOCBOOK_PROGRAMLISTING = NO
+# DOCBOOK_PROGRAMLISTING = NO
 
 #---------------------------------------------------------------------------
 # Configuration options for the AutoGen Definitions output
@@ -2220,7 +2220,7 @@ EXTERNAL_PAGES         = YES
 # powerful graphs.
 # The default value is: YES.
 
-CLASS_DIAGRAMS         = YES
+# CLASS_DIAGRAMS         = YES
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
@@ -2262,14 +2262,14 @@ DOT_NUM_THREADS        = 0
 # The default value is: Helvetica.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTNAME           = Helvetica
+# DOT_FONTNAME           = Helvetica
 
 # The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
 # dot graphs.
 # Minimum value: 4, maximum value: 24, default value: 10.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTSIZE           = 10
+# DOT_FONTSIZE           = 10
 
 # By default doxygen will tell dot to use the default font as specified with
 # DOT_FONTNAME. If you specify a different font using DOT_FONTNAME you can set
@@ -2493,7 +2493,7 @@ MAX_DOT_GRAPH_DEPTH    = 0
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_TRANSPARENT        = NO
+# DOT_TRANSPARENT        = NO
 
 # Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This

--- a/scripts/core/EUCount.yml
+++ b/scripts/core/EUCount.yml
@@ -36,5 +36,5 @@ members:
       name: numTotalEUs
       desc: "[out] Total number of EUs available"
 details:
-    - "This structure may be returned from $xDeviceGetProperties via `pNext` member of $x_device_properties_t"
+    - "This structure may be returned from $xDeviceGetProperties via the `pNext` member of $x_device_properties_t."
     - "Used for determining the total number of EUs available on device."

--- a/scripts/core/cacheReservation.yml
+++ b/scripts/core/cacheReservation.yml
@@ -32,11 +32,27 @@ class: $xDevice
 name: $x_cache_ext_region_t
 etors:
     - name: $X_CACHE_REGION_DEFAULT
-      desc: "utilize driver default scheme"
+      desc:
+            "1.6": "utilize driver default scheme"
+            "1.7": "[DEPRECATED] utilize driver default scheme. Use $X_CACHE_EXT_REGION_DEFAULT."
     - name: $X_CACHE_RESERVE_REGION
-      desc: "Utilize reserver region"
+      desc:
+            "1.6": "utilize reserved region"
+            "1.7": "[DEPRECATED] utilize reserved region. Use $X_CACHE_EXT_REGION_RESERVED."
     - name: $X_CACHE_NON_RESERVED_REGION
-      desc: "Utilize non-reserverd region"
+      desc:
+            "1.6": "utilize non-reserverd region"
+            "1.7": "[DEPRECATED] utilize non-reserverd region. Use $X_CACHE_EXT_REGION_NON_RESERVED."
+    - name: DEFAULT
+      desc: "utilize driver default scheme"
+      version: "1.7"
+      value: "0"
+    - name: RESERVED
+      desc: "utilize reserved region"
+      version: "1.7"
+    - name: NON_RESERVED
+      desc: "utilize non-reserverd region"
+      version: "1.7"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "CacheReservation structure"
@@ -49,7 +65,7 @@ members:
       name: maxCacheReservationSize
       desc: "[out] max cache reservation size"
 details:
-    - "This structure must be passed to $xDeviceGetCacheProperties via `pNext` member of $x_device_cache_properties_t"
+    - "This structure must be passed to $xDeviceGetCacheProperties via the `pNext` member of $x_device_cache_properties_t"
     - "Used for determining the max cache reservation allowed on device. Size of zero means no reservation available."
 --- #--------------------------------------------------------------------------
 type: function

--- a/scripts/core/cmdlist.yml
+++ b/scripts/core/cmdlist.yml
@@ -153,8 +153,8 @@ class: $xCommandList
 name: AppendWriteGlobalTimestamp
 details:
     - "The application must ensure the events are accessible by the device on which the command list was created."
-    - "The timestamp frequency can be queried from $x_device_properties_t.timerResolution."
-    - "The number of valid bits in the timestamp value can be queried from $x_device_properties_t.timestampValidBits."
+    - "The timestamp frequency can be queried from the `timerResolution` member of $x_device_properties_t."
+    - "The number of valid bits in the timestamp value can be queried from the `timestampValidBits` member of $x_device_properties_t."
     - "The application must ensure the memory pointed to by dstptr is accessible by the device on which the command list was created."
     - "The application must ensure the command list and events were created, and the memory was allocated, on the same context."
     - "The application must **not** call this function from simultaneous threads with the same command list handle."
@@ -201,7 +201,7 @@ params:
       desc: |
             [in] if non-zero, then indicates the maximum time (in nanoseconds) to yield before returning $X_RESULT_SUCCESS or $X_RESULT_NOT_READY;
             if zero, then immediately returns the status of the immediate command list;
-            if UINT64_MAX, then function will not return until complete or device is lost.
+            if `UINT64_MAX`, then function will not return until complete or device is lost.
             Due to external dependencies, timeout may be rounded to the closest value allowed by the accuracy of those dependencies.
 returns:
     - $X_RESULT_NOT_READY:

--- a/scripts/core/cmdqueue.yml
+++ b/scripts/core/cmdqueue.yml
@@ -181,7 +181,7 @@ params:
       desc: |
             [in] if non-zero, then indicates the maximum time (in nanoseconds) to yield before returning $X_RESULT_SUCCESS or $X_RESULT_NOT_READY;
             if zero, then immediately returns the status of the command queue;
-            if UINT64_MAX, then function will not return until complete or device is lost.
+            if `UINT64_MAX`, then function will not return until complete or device is lost.
             Due to external dependencies, timeout may be rounded to the closest value allowed by the accuracy of those dependencies.
 returns:
     - $X_RESULT_NOT_READY:

--- a/scripts/core/copy.yml
+++ b/scripts/core/copy.yml
@@ -60,7 +60,7 @@ details:
     - "The application must ensure the memory pointed to by dstptr is accessible by the device on which the command list was created."
     - "The implementation must not access the memory pointed to by dstptr as it is free to be modified by either the Host or device up until execution."
     - "The value to initialize memory to is described by the pattern and the pattern size."
-    - "The pattern size must be a power-of-two and less than or equal to $x_command_queue_group_properties_t.maxMemoryFillPatternSize."
+    - "The pattern size must be a power-of-two and less than or equal to the `maxMemoryFillPatternSize` member of $x_command_queue_group_properties_t."
     - "The application must ensure the events are accessible by the device on which the command list was created."
     - "The application must ensure the command list and events were created, and the memory was allocated, on the same context."
     - "The application must **not** call this function from simultaneous threads with the same command list handle."
@@ -150,7 +150,7 @@ params:
       desc: "[in] destination pitch in bytes"
     - type: "uint32_t"
       name: dstSlicePitch
-      desc: "[in] destination slice pitch in bytes. This is required for 3D region copies where $x_copy_region_t.depth is not 0, otherwise it's ignored."
+      desc: "[in] destination slice pitch in bytes. This is required for 3D region copies where the `depth` member of $x_copy_region_t is not 0, otherwise it's ignored."
     - type: "const void*"
       name: srcptr
       desc: "[in] pointer to source memory to copy from"
@@ -162,7 +162,7 @@ params:
       desc: "[in] source pitch in bytes"
     - type: "uint32_t"
       name: srcSlicePitch
-      desc: "[in] source slice pitch in bytes. This is required for 3D region copies where $x_copy_region_t.depth is not 0, otherwise it's ignored."
+      desc: "[in] source slice pitch in bytes. This is required for 3D region copies where the `depth` member of $x_copy_region_t is not 0, otherwise it's ignored."
     - type: $x_event_handle_t
       name: hSignalEvent
       desc: "[in][optional] handle of the event to signal on completion"

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -192,22 +192,22 @@ members:
       name: slice
       desc: |
             [in,out] the slice number.
-            Must be UINT32_MAX (all) or less than $x_device_properties_t.numSlices.
+            Must be `UINT32_MAX` (all) or less than the `numSlices` member of $x_device_properties_t.
     - type: "uint32_t"
       name: subslice
       desc: |
             [in,out] the sub-slice number within its slice.
-            Must be UINT32_MAX (all) or less than $x_device_properties_t.numSubslicesPerSlice.
+            Must be `UINT32_MAX` (all) or less than the `numSubslicesPerSlice` member of $x_device_properties_t.
     - type: "uint32_t"
       name: eu
       desc: |
             [in,out] the EU number within its sub-slice.
-            Must be UINT32_MAX (all) or less than $x_device_properties_t.numEUsPerSubslice.
+            Must be `UINT32_MAX` (all) or less than the `numEUsPerSubslice` member of $x_device_properties_t.
     - type: "uint32_t"
       name: thread
       desc: |
             [in,out] the thread number within its EU.
-            Must be UINT32_MAX (all) or less than $x_device_properties_t.numThreadsPerEU.
+            Must be `UINT32_MAX` (all) or less than the `numThreadsPerEU` member of $x_device_properties_t.
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves properties of the device."

--- a/scripts/core/deviceLUID.yml
+++ b/scripts/core/deviceLUID.yml
@@ -63,4 +63,4 @@ members:
             Otherwise, the returned node mask must be 1.
 
 details:
-    - "This structure may be returned from $xDeviceGetProperties, via `pNext` member of $x_device_properties_t."
+    - "This structure may be returned from $xDeviceGetProperties, via the `pNext` member of $x_device_properties_t."

--- a/scripts/core/deviceipversion.yml
+++ b/scripts/core/deviceipversion.yml
@@ -40,5 +40,5 @@ members:
             version than older devices.
 
 details:
-    - "This structure may be returned from $xDeviceGetProperties via `pNext` member of $x_device_properties_t"
+    - "This structure may be returned from $xDeviceGetProperties via the `pNext` member of $x_device_properties_t"
   

--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -331,7 +331,7 @@ params:
       desc: |
             [in] if non-zero, then indicates the maximum time (in nanoseconds) to yield before returning $X_RESULT_SUCCESS or $X_RESULT_NOT_READY;
             if zero, then operates exactly like $xEventQueryStatus;
-            if UINT64_MAX, then function will not return until complete or device is lost.
+            if `UINT64_MAX`, then function will not return until complete or device is lost.
             Due to external dependencies, timeout may be rounded to the closest value allowed by the accuracy of those dependencies.
 returns:
     - $X_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT
@@ -399,8 +399,8 @@ desc: "Kernel timestamp clock data"
 class: $xEvent
 name: $x_kernel_timestamp_data_t
 details:
-    - "The timestamp frequency can be queried from $x_device_properties_t.timerResolution."
-    - "The number of valid bits in the timestamp value can be queried from $x_device_properties_t.kernelTimestampValidBits."
+    - "The timestamp frequency can be queried from the `timerResolution` member of $x_device_properties_t."
+    - "The number of valid bits in the timestamp value can be queried from the `kernelTimestampValidBits` member of $x_device_properties_t."
 members:
     - type: uint64_t
       name: kernelStart

--- a/scripts/core/eventQueryKernelTimestamps.yml
+++ b/scripts/core/eventQueryKernelTimestamps.yml
@@ -46,7 +46,7 @@ members:
       name: flags
       desc: "[out] 0 or some combination of $x_event_query_kernel_timestamps_ext_flag_t flags"
 details:
-    - "This structure may be returned from $xDeviceGetProperties, via `pNext` member of $x_device_properties_t."
+    - "This structure may be returned from $xDeviceGetProperties, via the `pNext` member of $x_device_properties_t."
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Kernel timestamp clock data synchronized to the host time domain"

--- a/scripts/core/fence.yml
+++ b/scripts/core/fence.yml
@@ -92,7 +92,7 @@ params:
       desc: |
             [in] if non-zero, then indicates the maximum time (in nanoseconds) to yield before returning $X_RESULT_SUCCESS or $X_RESULT_NOT_READY;
             if zero, then operates exactly like $xFenceQueryStatus;
-            if UINT64_MAX, then function will not return until complete or device is lost.
+            if `UINT64_MAX`, then function will not return until complete or device is lost.
             Due to external dependencies, timeout may be rounded to the closest value allowed by the accuracy of those dependencies.
 returns:
     - $X_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT

--- a/scripts/core/floatAtomics.yml
+++ b/scripts/core/floatAtomics.yml
@@ -62,4 +62,4 @@ members:
       name: fp64Flags
       desc: "[out] Capabilities for double-precision floating-point atomic operations"
 details:
-    - "This structure may be returned from $xDeviceGetModuleProperties, via `pNext` member of $x_device_module_properties_t."
+    - "This structure may be returned from $xDeviceGetModuleProperties, via the `pNext` member of $x_device_module_properties_t."

--- a/scripts/core/image.yml
+++ b/scripts/core/image.yml
@@ -218,31 +218,31 @@ members:
       name: width
       desc: |
             [in] width dimension.
-            $X_IMAGE_TYPE_BUFFER: size in bytes; see $x_device_image_properties_t.maxImageBufferSize for limits.
-            $X_IMAGE_TYPE_1D, $X_IMAGE_TYPE_1DARRAY: width in pixels; see $x_device_image_properties_t.maxImageDims1D for limits.
-            $X_IMAGE_TYPE_2D, $X_IMAGE_TYPE_2DARRAY: width in pixels; see $x_device_image_properties_t.maxImageDims2D for limits.
-            $X_IMAGE_TYPE_3D: width in pixels; see $x_device_image_properties_t.maxImageDims3D for limits.
+            $X_IMAGE_TYPE_BUFFER: size in bytes; see the `maxImageBufferSize` member of $x_device_image_properties_t for limits.
+            $X_IMAGE_TYPE_1D, $X_IMAGE_TYPE_1DARRAY: width in pixels; see the `maxImageDims1D` member of $x_device_image_properties_t for limits.
+            $X_IMAGE_TYPE_2D, $X_IMAGE_TYPE_2DARRAY: width in pixels; see the `maxImageDims2D` member of $x_device_image_properties_t for limits.
+            $X_IMAGE_TYPE_3D: width in pixels; see the `maxImageDims3D` member of $x_device_image_properties_t for limits.
       init: "0"
     - type: uint32_t
       name: height
       desc: |
             [in] height dimension.
-            $X_IMAGE_TYPE_2D, $X_IMAGE_TYPE_2DARRAY: height in pixels; see $x_device_image_properties_t.maxImageDims2D for limits.
-            $X_IMAGE_TYPE_3D: height in pixels; see $x_device_image_properties_t.maxImageDims3D for limits.
+            $X_IMAGE_TYPE_2D, $X_IMAGE_TYPE_2DARRAY: height in pixels; see the `maxImageDims2D` member of $x_device_image_properties_t for limits.
+            $X_IMAGE_TYPE_3D: height in pixels; see the `maxImageDims3D` member of $x_device_image_properties_t for limits.
             other: ignored.
       init: "0"
     - type: uint32_t
       name: depth
       desc: |
             [in] depth dimension.
-            $X_IMAGE_TYPE_3D: depth in pixels; see $x_device_image_properties_t.maxImageDims3D for limits.
+            $X_IMAGE_TYPE_3D: depth in pixels; see the `maxImageDims3D` member of $x_device_image_properties_t for limits.
             other: ignored.
       init: "0"
     - type: uint32_t
       name: arraylevels
       desc: |
             [in] array levels.
-            $X_IMAGE_TYPE_1DARRAY, $X_IMAGE_TYPE_2DARRAY: see $x_device_image_properties_t.maxImageArraySlices for limits.
+            $X_IMAGE_TYPE_1DARRAY, $X_IMAGE_TYPE_2DARRAY: see the `maxImageArraySlices` member of $x_device_image_properties_t for limits.
             other: ignored.
       init: "1"
     - type: uint32_t

--- a/scripts/core/kernelSchedulingHints.yml
+++ b/scripts/core/kernelSchedulingHints.yml
@@ -51,7 +51,7 @@ members:
             [out] Supported kernel scheduling hints.
             May be 0 (none) or a valid combination of $x_scheduling_hint_exp_flag_t.
 details:
-    - "This structure may be returned from $xDeviceGetModuleProperties, via `pNext` member of $x_device_module_properties_t."
+    - "This structure may be returned from $xDeviceGetModuleProperties, via the `pNext` member of $x_device_module_properties_t."
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Kernel scheduling hint descriptor"

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -100,10 +100,10 @@ params:
       desc: "[in] pointer to host memory allocation descriptor"
     - type: size_t
       name: size
-      desc: "[in] size in bytes to allocate; must be less than or equal to $x_device_properties_t.maxMemAllocSize."
+      desc: "[in] size in bytes to allocate; must be less than or equal to the `maxMemAllocSize` member of $x_device_properties_t"
     - type: size_t
       name: alignment
-      desc: "[in] minimum alignment in bytes for the allocation; must be a power of two."
+      desc: "[in] minimum alignment in bytes for the allocation; must be a power of two"
     - type: "$x_device_handle_t"
       name: hDevice
       desc: "[in][optional] device handle to associate with"
@@ -137,10 +137,10 @@ params:
       desc: "[in] pointer to device memory allocation descriptor"
     - type: size_t
       name: size
-      desc: "[in] size in bytes to allocate; must be less than or equal to $x_device_properties_t.maxMemAllocSize."
+      desc: "[in] size in bytes to allocate; must be less than or equal to the `maxMemAllocSize` member of $x_device_properties_t"
     - type: size_t
       name: alignment
-      desc: "[in] minimum alignment in bytes for the allocation; must be a power of two."
+      desc: "[in] minimum alignment in bytes for the allocation; must be a power of two"
     - type: "$x_device_handle_t"
       name: hDevice
       desc: "[in] handle of the device"
@@ -175,10 +175,10 @@ params:
       desc: "[in] pointer to host memory allocation descriptor"
     - type: size_t
       name: size
-      desc: "[in] size in bytes to allocate; must be less than or equal to $x_device_properties_t.maxMemAllocSize."
+      desc: "[in] size in bytes to allocate; must be less than or equal to the `maxMemAllocSize` member of $x_device_properties_t"
     - type: size_t
       name: alignment
-      desc: "[in] minimum alignment in bytes for the allocation; must be a power of two."
+      desc: "[in] minimum alignment in bytes for the allocation; must be a power of two"
     - type: "void**"
       name: pptr
       desc: "[out] pointer to host allocation"

--- a/scripts/core/memoryCompressionHints.yml
+++ b/scripts/core/memoryCompressionHints.yml
@@ -50,6 +50,6 @@ members:
             Must be set to one of the $x_memory_compression_hints_ext_flag_t;
       init: "0"
 details:
-    - "This structure may be passed to $xMemAllocShared or $xMemAllocDevice, via `pNext` member of $x_device_mem_alloc_desc_t."
-    - "This structure may be passed to $xMemAllocHost, via `pNext` member of $x_host_mem_alloc_desc_t."
-    - "This structure may be passed to $xImageCreate, via `pNext` member of $x_image_desc_t."
+    - "This structure may be passed to $xMemAllocShared or $xMemAllocDevice, via the `pNext` member of $x_device_mem_alloc_desc_t."
+    - "This structure may be passed to $xMemAllocHost, via the `pNext` member of $x_host_mem_alloc_desc_t."
+    - "This structure may be passed to $xImageCreate, via the `pNext` member of $x_image_desc_t."

--- a/scripts/core/memoryFreePolicies.yml
+++ b/scripts/core/memoryFreePolicies.yml
@@ -50,7 +50,7 @@ members:
             must be 0 or a combination of $x_driver_memory_free_policy_ext_flag_t.
 details:
     - "All drivers must support an immediate free policy, which is the default free policy."
-    - "This structure may be returned from $xDriverGetProperties, via `pNext` member of $x_driver_properties_t."
+    - "This structure may be returned from $xDriverGetProperties, via the `pNext` member of $x_driver_properties_t."
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Memory free descriptor with free policy"

--- a/scripts/core/raytracing.yml
+++ b/scripts/core/raytracing.yml
@@ -51,7 +51,7 @@ members:
       name: maxBVHLevels
       desc: "[out] Maximum number of BVH levels supported"
 details:
-    - "This structure may be returned from $xDeviceGetModuleProperties, via `pNext` member of $x_device_module_properties_t."
+    - "This structure may be returned from $xDeviceGetModuleProperties, via the `pNext` member of $x_device_module_properties_t."
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Supported raytracing memory allocation flags"
@@ -77,4 +77,4 @@ members:
             default behavior may use implicit driver-based heuristics.
       init: "0"
 details:
-    - "This structure must be passed to $xMemAllocShared or $xMemAllocDevice, via `pNext` member of $x_device_mem_alloc_desc_t, for any memory allocation that is to be accessed by raytracing fixed-function of the device."
+    - "This structure must be passed to $xMemAllocShared or $xMemAllocDevice, via the `pNext` member of $x_device_mem_alloc_desc_t, for any memory allocation that is to be accessed by raytracing fixed-function of the device."

--- a/scripts/core/relaxedAllocLimits.yml
+++ b/scripts/core/relaxedAllocLimits.yml
@@ -32,7 +32,7 @@ class: $xMem
 name: $x_relaxed_allocation_limits_exp_flags_t
 etors:
     - name: MAX_SIZE
-      desc: "Allocation size may exceed $x_device_properties_t.maxMemAllocSize"
+      desc: "Allocation size may exceed the `maxMemAllocSize` member of $x_device_properties_t."
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Relaxed limits memory allocation descriptor"
@@ -48,5 +48,5 @@ members:
             must be 0 (default) or a valid combination of $x_relaxed_allocation_limits_exp_flag_t;
       init: "0"
 details:
-    - "This structure may be passed to $xMemAllocShared or $xMemAllocDevice, via `pNext` member of $x_device_mem_alloc_desc_t."
-    - "This structure may also be passed to $xMemAllocHost, via `pNext` member of $x_host_mem_alloc_desc_t."
+    - "This structure may be passed to $xMemAllocShared or $xMemAllocDevice, via the `pNext` member of $x_device_mem_alloc_desc_t."
+    - "This structure may also be passed to $xMemAllocHost, via the `pNext` member of $x_host_mem_alloc_desc_t."

--- a/scripts/core/subAllocationsProperties.yml
+++ b/scripts/core/subAllocationsProperties.yml
@@ -57,4 +57,4 @@ members:
             [in,out][optional][range(0, *pCount)] array of properties for sub-allocations.
             if count is less than the number of sub-allocations available, then driver shall only retrieve properties for that number of sub-allocations.
 details:
-    - "This structure may be passed to $xMemGetAllocProperties, via `pNext` member of $x_memory_allocation_properties_t."
+    - "This structure may be passed to $xMemGetAllocProperties, via the `pNext` member of $x_memory_allocation_properties_t."

--- a/scripts/core/virtual.yml
+++ b/scripts/core/virtual.yml
@@ -235,7 +235,7 @@ params:
       name: size
       desc: "[in] size in bytes to unmap; must be page aligned."
 returns:
-    - $X_RESULT_ERROR_UNSUPPORTED_ALIGNMENT
+    - $X_RESULT_ERROR_UNSUPPORTED_ALIGNMENT:
         - "Address must be page aligned"
     - $X_RESULT_ERROR_UNSUPPORTED_SIZE:
         - "`0 == size`"
@@ -264,7 +264,7 @@ params:
       name: access
       desc: "[in] specifies page access attributes to apply to the virtual address range."
 returns:
-    - $X_RESULT_ERROR_UNSUPPORTED_ALIGNMENT
+    - $X_RESULT_ERROR_UNSUPPORTED_ALIGNMENT:
         - "Address must be page aligned"
     - $X_RESULT_ERROR_UNSUPPORTED_SIZE:
         - "`0 == size`"
@@ -297,7 +297,7 @@ params:
       name: outSize
       desc: "[out] query result for size of virtual address range, starting at ptr, that shares same access attribute."
 returns:
-    - $X_RESULT_ERROR_UNSUPPORTED_ALIGNMENT
+    - $X_RESULT_ERROR_UNSUPPORTED_ALIGNMENT:
         - "Address must be page aligned"
     - $X_RESULT_ERROR_UNSUPPORTED_SIZE:
         - "`0 == size`"

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -61,7 +61,7 @@ def _find_enum_from_etor(etor, meta):
 """
     make restructedtext reference from symbol.
 """
-def _make_ref(symbol, symbol_type, meta):
+def _make_ref(fin, iline, symbol, symbol_type, meta):
     if not re.match(r"function|struct|union|enum|etor", symbol_type):
         return ""
 
@@ -134,7 +134,7 @@ def _generate_valid_rst(fin, fout, namespace, tags, ver, rev, meta):
                             print("%s(%s) : error : %s parameter count mismatch - %s actual vs. %s expected"%(fin, iline+1, symbol, len(words), len(meta['function'][symbol]['params'])))
                             print("line = %s"%line)
 
-                    ref = _make_ref(symbol, symbol_type, meta)
+                    ref = _make_ref(fin, iline, symbol, symbol_type, meta)
                     if ref:
                         tuple = line.partition(word)
 

--- a/scripts/sysman/device.yml
+++ b/scripts/sysman/device.yml
@@ -179,9 +179,9 @@ params:
 returns:
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to perform this operation."
-    - $X_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+    - $X_RESULT_ERROR_HANDLE_OBJECT_IN_USE:
         - "Reset cannot be performed because applications are using this device."
-    - $X_RESULT_ERROR_UNKNOWN
+    - $X_RESULT_ERROR_UNKNOWN:
         - "There were problems unloading the device driver, performing a bus reset or reloading the device driver."
 
 --- #--------------------------------------------------------------------------
@@ -281,13 +281,13 @@ members:
       desc: "[out] Fastest port configuration supported by the device (sum of all lanes)"
     - type: $x_bool_t
       name: "haveBandwidthCounters"
-      desc: "[out] Indicates if $s_pci_stats_t.rxCounter and $s_pci_stats_t.txCounter will have valid values"
+      desc: "[out] Indicates whether the `rxCounter` and `txCounter` members of $s_pci_stats_t will have valid values"
     - type: $x_bool_t
       name: "havePacketCounters"
-      desc: "[out] Indicates if $s_pci_stats_t.packetCounter will have valid values"
+      desc: "[out] Indicates whether the `packetCounter` member of $s_pci_stats_t will have a valid value"
     - type: $x_bool_t
       name: "haveReplayCounters"
-      desc: "[out] Indicates if $s_pci_stats_t.replayCounter will have valid values"
+      desc: "[out] Indicates whether the `replayCounter` member of $s_pci_stats_t will have a valid value"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "PCI link status"
@@ -422,16 +422,16 @@ members:
             The absolute value of the timestamp is only valid during within the application and may be different on the next execution.
     - type: uint64_t
       name: "replayCounter"
-      desc: "[out] Monotonic counter for the number of replay packets (sum of all lanes). Will always be 0 if $s_pci_properties_t.haveReplayCounters is FALSE."
+      desc: "[out] Monotonic counter for the number of replay packets (sum of all lanes). Will always be 0 when the `haveReplayCounters` member of $s_pci_properties_t is FALSE."
     - type: uint64_t
       name: "packetCounter"
-      desc: "[out] Monotonic counter for the number of packets (sum of all lanes). Will always be 0 if $s_pci_properties_t.havePacketCounters is FALSE."
+      desc: "[out] Monotonic counter for the number of packets (sum of all lanes). Will always be 0 when the `havePacketCounters` member of $s_pci_properties_t is FALSE."
     - type: uint64_t
       name: "rxCounter"
-      desc: "[out] Monotonic counter for the number of bytes received (sum of all lanes). Will always be 0 if $s_pci_properties_t.haveBandwidthCounters is FALSE."
+      desc: "[out] Monotonic counter for the number of bytes received (sum of all lanes). Will always be 0 when the `haveBandwidthCounters` member of $s_pci_properties_t is FALSE."
     - type: uint64_t
       name: "txCounter"
-      desc: "[out] Monotonic counter for the number of bytes transmitted (including replays) (sum of all lanes). Will always be 0 if $s_pci_properties_t.haveBandwidthCounters is FALSE."
+      desc: "[out] Monotonic counter for the number of bytes transmitted (including replays) (sum of all lanes). Will always be 0 when the `haveBandwidthCounters` member of $s_pci_properties_t is FALSE."
     - type: $s_pci_speed_t
       name: "speed"
       desc: "[out] The current speed of the link (sum of all lanes)"

--- a/scripts/sysman/diagnostics.yml
+++ b/scripts/sysman/diagnostics.yml
@@ -104,11 +104,11 @@ params:
       desc: "[in,out] Structure describing the properties of a diagnostics test suite"
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Get individual tests that can be run separately. Not all test suites permit running individual tests - check $s_diag_properties_t.haveTests"
+desc: "Get individual tests that can be run separately. Not all test suites permit running individual tests, check the `haveTests` member of $s_diag_properties_t."
 class: $sDiagnostics
 name: GetTests
 details:
-    - "The list of available tests is returned in order of increasing test index $s_diag_test_t.index."
+    - "The list of available tests is returned in order of increasing test index (see the `index` member of $s_diag_test_t)."
     - "The application may call this function from simultaneous threads."
     - "The implementation of this function should be lock-free."
 params:
@@ -124,7 +124,7 @@ params:
     - type: "$s_diag_test_t*"
       name: pTests
       desc: |
-            [in,out][optional][range(0, *pCount)] array of information about individual tests sorted by increasing value of $s_diag_test_t.index.
+            [in,out][optional][range(0, *pCount)] array of information about individual tests sorted by increasing value of the `index` member of $s_diag_test_t.
             if count is less than the number of tests that are available, then the driver shall only retrieve that number of tests.
 --- #--------------------------------------------------------------------------
 type: function
@@ -134,7 +134,7 @@ name: RunTests
 details:
     - "WARNING: Running diagnostics may destroy current device state information. Gracefully close any running workloads before initiating."
     - "To run all tests in a test suite, set start = $S_DIAG_FIRST_TEST_INDEX and end = $S_DIAG_LAST_TEST_INDEX."
-    - "If the test suite permits running individual tests, $s_diag_properties_t.haveTests will be true. In this case, the function $sDiagnosticsGetTests() can be called to get the list of tests and corresponding indices that can be supplied to the arguments start and end in this function."
+    - "If the test suite permits running individual tests, the `haveTests` member of $s_diag_properties_t will be true. In this case, the function $sDiagnosticsGetTests() can be called to get the list of tests and corresponding indices that can be supplied to the arguments start and end in this function."
     - "This function will block until the diagnostics have completed and force reset based on result"
 params:
     - type: $s_diag_handle_t

--- a/scripts/sysman/events.yml
+++ b/scripts/sysman/events.yml
@@ -77,7 +77,7 @@ params:
       desc: |
             [in] if non-zero, then indicates the maximum time (in milliseconds) to yield before returning $X_RESULT_SUCCESS or $X_RESULT_NOT_READY;
             if zero, then will check status and return immediately;
-            if UINT32_MAX, then function will not return until events arrive.
+            if `UINT32_MAX`, then function will not return until events arrive.
     - type: uint32_t
       name: count
       desc: "[in] Number of device handles in phDevices."
@@ -117,7 +117,7 @@ params:
       desc: |
             [in] if non-zero, then indicates the maximum time (in milliseconds) to yield before returning $X_RESULT_SUCCESS or $X_RESULT_NOT_READY;
             if zero, then will check status and return immediately;
-            if UINT64_MAX, then function will not return until events arrive.
+            if `UINT64_MAX`, then function will not return until events arrive.
     - type: uint32_t
       name: count
       desc: "[in] Number of device handles in phDevices."

--- a/scripts/sysman/fabric.yml
+++ b/scripts/sysman/fabric.yml
@@ -64,7 +64,7 @@ class: $sFabricPort
 name: $s_fabric_port_id_t
 details:
     - "This not a universal identifier. The identified is garanteed to be unique for the current hardware configuration of the system. Changes in the hardware may result in a different identifier for a given port."
-    - "The main purpose of this identifier to build up an instantaneous topology map of system connectivity. An application should enumerate all fabric ports and match $s_fabric_port_state_t.remotePortId to $s_fabric_port_properties_t.portId."
+    - "The main purpose of this identifier to build up an instantaneous topology map of system connectivity. An application should enumerate all fabric ports and match the `remotePortId` member of $s_fabric_port_state_t to the `portId` member of $s_fabric_port_properties_t."
 members:
     - type: uint32_t
       name: "fabricId"

--- a/scripts/sysman/fan.yml
+++ b/scripts/sysman/fan.yml
@@ -204,7 +204,7 @@ returns:
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to make these modifications."
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Fixing the fan speed not supported by the hardware or the fan speed units are not supported. See $s_fan_properties_t.supportedModes and $s_fan_properties_t.supportedUnits."
+        - "Fixing the fan speed not supported by the hardware or the fan speed units are not supported. See the `supportedModes` and `supportedUnits` members of $s_fan_properties_t."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Configure the fan to adjust speed based on a temperature/speed table (set mode to $S_FAN_SPEED_MODE_TABLE)"
@@ -226,7 +226,7 @@ returns:
     - $X_RESULT_ERROR_INVALID_ARGUMENT:
         - "The temperature/speed pairs in the array are not sorted on temperature from lowest to highest."
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Fan speed table not supported by the hardware or the fan speed units are not supported. See $s_fan_properties_t.supportedModes and $s_fan_properties_t.supportedUnits."
+        - "Fan speed table not supported by the hardware or the fan speed units are not supported. See the `supportedModes` and `supportedUnits` members of $s_fan_properties_t."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Get current state of a fan - current mode and speed"
@@ -247,7 +247,7 @@ params:
       desc: "[in,out] Will contain the current speed of the fan in the units requested. A value of -1 indicates that the fan speed cannot be measured."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "The requested fan speed units are not supported. See $s_fan_properties_t.supportedUnits."
+        - "The requested fan speed units are not supported. See the `supportedUnits` member of $s_fan_properties_t."
 --- #--------------------------------------------------------------------------
 type: class
 desc: "C++ wrapper for a Sysman device fan"

--- a/scripts/sysman/frequency.yml
+++ b/scripts/sysman/frequency.yml
@@ -336,7 +336,7 @@ params:
       desc: "[in] Handle for the component."
     - type: $s_oc_capabilities_t*
       name: pOcCapabilities
-      desc: "[in,out] Pointer to the capabilities structure $s_oc_capabilities_t."
+      desc: "[in,out] Pointer to the capabilities structure."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Get the current overclocking frequency target, if extended moded is supported, will returned in 1 Mhz granularity."
@@ -351,14 +351,14 @@ params:
       desc: "[in] Handle for the component."
     - type: double*
       name: pCurrentOcFrequency
-      desc: "[out] Overclocking Frequency in MHz, if extended moded is supported, will returned in 1 Mhz granularity, else, in multiples of 50 Mhz. This cannot be greater than $s_oc_capabilities_t.maxOcFrequency."
+      desc: "[out] Overclocking Frequency in MHz, if extended moded is supported, will returned in 1 Mhz granularity, else, in multiples of 50 Mhz. This cannot be greater than the `maxOcFrequency` member of $s_oc_capabilities_t."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Overclocking is not supported on this frequency domain ($s_oc_capabilities_t.isOcSupported)"
-        - "The specified voltage and/or frequency overclock settings exceed the hardware values (see $s_oc_capabilities_t.maxOcFrequency, $s_oc_capabilities_t.maxOcVoltage, $s_oc_capabilities_t.minOcVoltageOffset, $s_oc_capabilities_t.maxOcVoltageOffset)."
-        - "Requested voltage overclock is very high but $s_oc_capabilities_t.isHighVoltModeEnabled is not enabled for the device."
+        - "Overclocking is not supported on this frequency domain (see the `isOcSupported` member of $s_oc_capabilities_t)."
+        - "The specified voltage and/or frequency overclock settings exceed the hardware values (see the `maxOcFrequency`, `maxOcVoltage`, `minOcVoltageOffset` and `maxOcVoltageOffset` members of $s_oc_capabilities_t)."
+        - "Requested voltage overclock is very high but the `isHighVoltModeEnabled` member of $s_oc_capabilities_t is not enabled for the device."
     - $X_RESULT_ERROR_NOT_AVAILABLE:
-        - "Overclocking feature is locked on this frequency domain"
+        - "Overclocking feature is locked on this frequency domain."
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to make these modifications."
 --- #--------------------------------------------------------------------------
@@ -375,14 +375,14 @@ params:
       desc: "[in] Handle for the component."
     - type: double
       name: CurrentOcFrequency
-      desc: "[in] Overclocking Frequency in MHz, if extended moded is supported, it could be set in 1 Mhz granularity, else, in multiples of 50 Mhz. This cannot be greater than $s_oc_capabilities_t.maxOcFrequency."
+      desc: "[in] Overclocking Frequency in MHz, if extended moded is supported, it could be set in 1 Mhz granularity, else, in multiples of 50 Mhz. This cannot be greater than the `maxOcFrequency` member of $s_oc_capabilities_t."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Overclocking is not supported on this frequency domain ($s_oc_capabilities_t.isOcSupported)"
-        - "The specified voltage and/or frequency overclock settings exceed the hardware values (see $s_oc_capabilities_t.maxOcFrequency, $s_oc_capabilities_t.maxOcVoltage, $s_oc_capabilities_t.minOcVoltageOffset, $s_oc_capabilities_t.maxOcVoltageOffset)."
-        - "Requested voltage overclock is very high but $s_oc_capabilities_t.isHighVoltModeEnabled is not enabled for the device."
+        - "Overclocking is not supported on this frequency domain (see the `isOcSupported` member of $s_oc_capabilities_t)."
+        - "The specified voltage and/or frequency overclock settings exceed the hardware values (see the `maxOcFrequency`, `maxOcVoltage`, `minOcVoltageOffset` and `maxOcVoltageOffset` members of $s_oc_capabilities_t)."
+        - "Requested voltage overclock is very high but the `isHighVoltModeEnabled` member of $s_oc_capabilities_t is not enabled for the device."
     - $X_RESULT_ERROR_NOT_AVAILABLE:
-        - "Overclocking feature is locked on this frequency domain"
+        - "Overclocking feature is locked on this frequency domain."
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to make these modifications."      
 --- #--------------------------------------------------------------------------
@@ -399,17 +399,17 @@ params:
       desc: "[in] Handle for the component."
     - type: double*
       name: pCurrentVoltageTarget
-      desc: "[out] Overclock voltage in Volts. This cannot be greater than $s_oc_capabilities_t.maxOcVoltage."
+      desc: "[out] Overclock voltage in Volts. This cannot be greater than the `maxOcVoltage` member of $s_oc_capabilities_t."
     - type: double*
       name: pCurrentVoltageOffset
-      desc: "[out] This voltage offset is applied to all points on the voltage/frequency curve, include the new overclock voltageTarget. It can be in the range ($s_oc_capabilities_t.minOcVoltageOffset, $s_oc_capabilities_t.maxOcVoltageOffset)."
+      desc: "[out] This voltage offset is applied to all points on the voltage/frequency curve, including the new overclock voltageTarget. Valid range is between the `minOcVoltageOffset` and `maxOcVoltageOffset` members of $s_oc_capabilities_t."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Overclocking is not supported on this frequency domain ($s_oc_capabilities_t.isOcSupported)"
-        - "The specified voltage and/or frequency overclock settings exceed the hardware values (see $s_oc_capabilities_t.maxOcFrequency, $s_oc_capabilities_t.maxOcVoltage, $s_oc_capabilities_t.minOcVoltageOffset, $s_oc_capabilities_t.maxOcVoltageOffset)."
-        - "Requested voltage overclock is very high but $s_oc_capabilities_t.isHighVoltModeEnabled is not enabled for the device."
+        - "Overclocking is not supported on this frequency domain (see the `isOcSupported` member of $s_oc_capabilities_t)."
+        - "The specified voltage and/or frequency overclock settings exceed the hardware values (see the `maxOcFrequency`, `maxOcVoltage`, `minOcVoltageOffset` and `maxOcVoltageOffset` members of $s_oc_capabilities_t)."
+        - "Requested voltage overclock is very high but the `isHighVoltModeEnabled` member of $s_oc_capabilities_t is not enabled for the device."
     - $X_RESULT_ERROR_NOT_AVAILABLE:
-        - "Overclocking feature is locked on this frequency domain"
+        - "Overclocking feature is locked on this frequency domain."
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to make these modifications."      
 --- #--------------------------------------------------------------------------
@@ -426,17 +426,17 @@ params:
       desc: "[in] Handle for the component."
     - type: double
       name: CurrentVoltageTarget
-      desc: "[in] Overclock voltage in Volts. This cannot be greater than $s_oc_capabilities_t.maxOcVoltage."
+      desc: "[in] Overclock voltage in Volts. This cannot be greater than the `maxOcVoltage` member of $s_oc_capabilities_t."
     - type: double
       name: CurrentVoltageOffset
-      desc: "[in] This voltage offset is applied to all points on the voltage/frequency curve, include the new overclock voltageTarget. It can be in the range ($s_oc_capabilities_t.minOcVoltageOffset, $s_oc_capabilities_t.maxOcVoltageOffset)."
+      desc: "[in] This voltage offset is applied to all points on the voltage/frequency curve, include the new overclock voltageTarget. Valid range is between the `minOcVoltageOffset` and `maxOcVoltageOffset` members of $s_oc_capabilities_t."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Overclocking is not supported on this frequency domain ($s_oc_capabilities_t.isOcSupported)"
-        - "The specified voltage and/or frequency overclock settings exceed the hardware values (see $s_oc_capabilities_t.maxOcFrequency, $s_oc_capabilities_t.maxOcVoltage, $s_oc_capabilities_t.minOcVoltageOffset, $s_oc_capabilities_t.maxOcVoltageOffset)."
-        - "Requested voltage overclock is very high but $s_oc_capabilities_t.isHighVoltModeEnabled is not enabled for the device."
+        - "Overclocking is not supported on this frequency domain (see the `isOcSupported` member of $s_oc_capabilities_t)."
+        - "The specified voltage and/or frequency overclock settings exceed the hardware values (see the `maxOcFrequency`, `maxOcVoltage`, `minOcVoltageOffset` and `maxOcVoltageOffset` members of $s_oc_capabilities_t)."
+        - "Requested voltage overclock is very high but the `isHighVoltModeEnabled` member of $s_oc_capabilities_t is not enabled for the device."
     - $X_RESULT_ERROR_NOT_AVAILABLE:
-        - "Overclocking feature is locked on this frequency domain"
+        - "Overclocking feature is locked on this frequency domain."
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to make these modifications."      
 --- #--------------------------------------------------------------------------
@@ -456,11 +456,11 @@ params:
       desc: "[in] Current Overclocking Mode $s_oc_mode_t."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Overclocking is not supported on this frequency domain ($s_oc_capabilities_t.isOcSupported)"
-        - "The specified voltage and/or frequency overclock settings exceed the hardware values (see $s_oc_capabilities_t.maxOcFrequency, $s_oc_capabilities_t.maxOcVoltage, $s_oc_capabilities_t.minOcVoltageOffset, $s_oc_capabilities_t.maxOcVoltageOffset)."
-        - "Requested voltage overclock is very high but $s_oc_capabilities_t.isHighVoltModeEnabled is not enabled for the device."
+        - "Overclocking is not supported on this frequency domain (see the `isOcSupported` member of $s_oc_capabilities_t)."
+        - "The specified voltage and/or frequency overclock settings exceed the hardware values (see the `maxOcFrequency`, `maxOcVoltage`, `minOcVoltageOffset` and `maxOcVoltageOffset` members of $s_oc_capabilities_t)."
+        - "Requested voltage overclock is very high but the `isHighVoltModeEnabled` member of $s_oc_capabilities_t is not enabled for the device."
     - $X_RESULT_ERROR_NOT_AVAILABLE:
-        - "Overclocking feature is locked on this frequency domain"
+        - "Overclocking feature is locked on this frequency domain."
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to make these modifications."       
 --- #--------------------------------------------------------------------------
@@ -480,11 +480,11 @@ params:
       desc: "[out] Current Overclocking Mode $s_oc_mode_t."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Overclocking is not supported on this frequency domain ($s_oc_capabilities_t.isOcSupported)"
-        - "The specified voltage and/or frequency overclock settings exceed the hardware values (see $s_oc_capabilities_t.maxOcFrequency, $s_oc_capabilities_t.maxOcVoltage, $s_oc_capabilities_t.minOcVoltageOffset, $s_oc_capabilities_t.maxOcVoltageOffset)."
-        - "Requested voltage overclock is very high but $s_oc_capabilities_t.isHighVoltModeEnabled is not enabled for the device."
+        - "Overclocking is not supported on this frequency domain (see the `isOcSupported` member of $s_oc_capabilities_t)."
+        - "The specified voltage and/or frequency overclock settings exceed the hardware values (see the `maxOcFrequency`, `maxOcVoltage`, `minOcVoltageOffset` and `maxOcVoltageOffset` members of $s_oc_capabilities_t)."
+        - "Requested voltage overclock is very high but the `isHighVoltModeEnabled` member of $s_oc_capabilities_t is not enabled for the device."
     - $X_RESULT_ERROR_NOT_AVAILABLE:
-        - "Overclocking feature is locked on this frequency domain"
+        - "Overclocking feature is locked on this frequency domain."
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to make these modifications."      
 --- #--------------------------------------------------------------------------
@@ -504,8 +504,8 @@ params:
       desc: "[in,out] Will contain the maximum current limit in Amperes on successful return."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Overclocking is not supported on this frequency domain ($s_oc_capabilities_t.isOcSupported)"
-        - "Capability $s_oc_capabilities_t.isIccMaxSupported is false for this frequency domain"
+        - "Overclocking is not supported on this frequency domain (see the `isOcSupported` member of $s_oc_capabilities_t)."
+        - "Capability the `isIccMaxSupported` member of $s_oc_capabilities_t is false for this frequency domain."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Change the maximum current limit setting."
@@ -524,12 +524,12 @@ params:
       desc: "[in] The new maximum current limit in Amperes."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Overclocking is not supported on this frequency domain ($s_oc_capabilities_t.isOcSupported)"
-        - "Capability $s_oc_capabilities_t.isIccMaxSupported is false for this frequency domain"
+        - "Overclocking is not supported on this frequency domain (see the `isOcSupported` member of $s_oc_capabilities_t)."
+        - "The `isIccMaxSupported` member of $s_oc_capabilities_t is false for this frequency domain."
     - $X_RESULT_ERROR_NOT_AVAILABLE:
-        - "Overclocking feature is locked on this frequency domain"
+        - "Overclocking feature is locked on this frequency domain."
     - $X_RESULT_ERROR_INVALID_ARGUMENT:
-        - "The specified current limit is too low or too high"
+        - "The specified current limit is too low or too high."
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to make these modifications."
 --- #--------------------------------------------------------------------------
@@ -549,7 +549,7 @@ params:
       desc: "[in,out] Will contain the maximum temperature limit in degrees Celsius on successful return."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Overclocking is not supported on this frequency domain ($s_oc_capabilities_t.isOcSupported)"
+        - "Overclocking is not supported on this frequency domain (see the `isOcSupported` member of $s_oc_capabilities_t)."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Change the maximum temperature limit setting."
@@ -568,12 +568,12 @@ params:
       desc: "[in] The new maximum temperature limit in degrees Celsius."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Overclocking is not supported on this frequency domain ($s_oc_capabilities_t.isOcSupported)"
-        - "Capability $s_oc_capabilities_t.isTjMaxSupported is false for this frequency domain"
+        - "Overclocking is not supported on this frequency domain (see the `isOcSupported` member of $s_oc_capabilities_t)."
+        - "The `isTjMaxSupported` member of $s_oc_capabilities_t is false for this frequency domain."
     - $X_RESULT_ERROR_NOT_AVAILABLE:
-        - "Overclocking feature is locked on this frequency domain"
+        - "Overclocking feature is locked on this frequency domain."
     - $X_RESULT_ERROR_INVALID_ARGUMENT:
-        - "The specified temperature limit is too high"
+        - "The specified temperature limit is too high."
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to make these modifications."
 --- #--------------------------------------------------------------------------

--- a/scripts/sysman/led.yml
+++ b/scripts/sysman/led.yml
@@ -145,7 +145,7 @@ returns:
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to make these modifications."
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "This LED doesn't not support color changes. See $s_led_properties_t.haveRGB."
+        - "This LED doesn't not support color changes. See the `haveRGB` member of $s_led_properties_t."
 --- #--------------------------------------------------------------------------
 type: class
 desc: "C++ wrapper for a Sysman device LED"

--- a/scripts/sysman/memory.yml
+++ b/scripts/sysman/memory.yml
@@ -129,7 +129,7 @@ members:
       desc: "[out] The free memory in bytes"
     - type: uint64_t
       name: size
-      desc: "[out] The total allocatable memory in bytes (can be less than $s_mem_properties_t.physicalSize)"
+      desc: "[out] The total allocatable memory in bytes (can be less than the `physicalSize` member of $s_mem_properties_t)"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Memory bandwidth"

--- a/scripts/sysman/power.yml
+++ b/scripts/sysman/power.yml
@@ -315,7 +315,7 @@ params:
       desc: "[in,out] Returns information about the energy threshold setting - enabled/energy threshold/process ID."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Energy threshold not supported on this power domain (check $s_power_properties_t.isEnergyThresholdSupported)."
+        - "Energy threshold not supported on this power domain (check the `isEnergyThresholdSupported` member of $s_power_properties_t)."
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to request this feature."
 --- #--------------------------------------------------------------------------
@@ -339,7 +339,7 @@ params:
       desc: "[in] The energy threshold to be set in joules."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Energy threshold not supported on this power domain (check $s_power_properties_t.isEnergyThresholdSupported)."
+        - "Energy threshold not supported on this power domain (check the `isEnergyThresholdSupported` member of $s_power_properties_t)."
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to request this feature."
     - $X_RESULT_ERROR_NOT_AVAILABLE:

--- a/scripts/sysman/scheduler.yml
+++ b/scripts/sysman/scheduler.yml
@@ -84,7 +84,7 @@ class: $sDevice
 name: EnumSchedulers
 details:
     - "Each scheduler component manages the distribution of work across one or more accelerator engines."
-    - "If an application wishes to change the scheduler behavior for all accelerator engines of a specific type (e.g. compute), it should select all the handles where the structure member $s_sched_properties_t.engines contains that type."
+    - "If an application wishes to change the scheduler behavior for all accelerator engines of a specific type (e.g. compute), it should select all the handles where the `engines` member $s_sched_properties_t contains that type."
     - "The application may call this function from simultaneous threads."
     - "The implementation of this function should be lock-free."
 params:

--- a/scripts/sysman/temperature.yml
+++ b/scripts/sysman/temperature.yml
@@ -141,8 +141,8 @@ params:
       desc: "[in,out] Returns current configuration."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Temperature thresholds are not supported on this temperature sensor. Generally this is only supported for temperature sensor $S_TEMP_SENSORS_GLOBAL"
-        - "One or both of the thresholds is not supported - check $s_temp_properties_t.isThreshold1Supported and $s_temp_properties_t.isThreshold2Supported"
+        - "Temperature thresholds are not supported on this temperature sensor. Generally this is only supported for temperature sensor $S_TEMP_SENSORS_GLOBAL."
+        - "One or both of the thresholds is not supported. Check the `isThreshold1Supported` and `isThreshold2Supported` members of $s_temp_properties_t."
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to request this feature."
 --- #--------------------------------------------------------------------------
@@ -165,9 +165,9 @@ params:
       desc: "[in] New configuration."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "Temperature thresholds are not supported on this temperature sensor. Generally they are only supported for temperature sensor $S_TEMP_SENSORS_GLOBAL"
-        - "Enabling the critical temperature event is not supported - check $s_temp_properties_t.isCriticalTempSupported"
-        - "One or both of the thresholds is not supported - check $s_temp_properties_t.isThreshold1Supported and $s_temp_properties_t.isThreshold2Supported"
+        - "Temperature thresholds are not supported on this temperature sensor. Generally they are only supported for temperature sensor $S_TEMP_SENSORS_GLOBAL."
+        - "Enabling the critical temperature event is not supported. Check the `isCriticalTempSupported` member of $s_temp_properties_t."
+        - "One or both of the thresholds is not supported. Check the `isThreshold1Supported` and `isThreshold2Supported` members of $s_temp_properties_t."
     - $X_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
         - "User does not have permissions to request this feature."
     - $X_RESULT_ERROR_NOT_AVAILABLE:

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -595,7 +595,7 @@ def make_etor_lines(namespace, tags, obj, py=False, meta=None):
 
         comment_style = "##" if py else "///<"
         for line in split_line(subt(namespace, tags, item['desc'], True), 70):
-            lines.append("%s%s %s"%(append_ws(prologue, 48), comment_style, line))
+            lines.append("%s%s %s"%(append_ws(prologue, 72), comment_style, line))
             prologue = ""
 
     if not py:
@@ -678,7 +678,7 @@ def make_member_lines(namespace, tags, obj, prefix="", py=False, meta=None):
             prologue = "%s %s;"%(tname, name)
 
         comment_style = "##" if py else "///<"
-        ws_count = 64 if py else 48
+        ws_count = 64 if py else 72
         for line in split_line(subt(namespace, tags, item['desc'], True), 70):
             lines.append("%s%s %s"%(append_ws(prologue, ws_count), comment_style, line))
             prologue = ""
@@ -726,7 +726,7 @@ def make_param_lines(namespace, tags, obj, py=False, decl=False, meta=None, form
         if "desc" in format:
             desc = item['desc']
             for line in split_line(subt(namespace, tags, desc, True), 70):
-                lines.append("%s///< %s"%(append_ws(prologue, 48), line))
+                lines.append("%s///< %s"%(append_ws(prologue, 72), line))
                 prologue = ""
         else:
             lines.append(prologue)

--- a/scripts/tools/EXT_Exp_MetricExportData.rst
+++ b/scripts/tools/EXT_Exp_MetricExportData.rst
@@ -40,13 +40,13 @@ The following code shows how to export metrics raw data for a metric group.
     uint32_t dataCount = 0;
     uint32_t totalMetricCount = 0;
     ${t}_metric_group_calculation_type_t type = ${T}_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
-    ${t}MetricGroupCalculateMetricExportDataExp (hDriver, type, &exportDataSize, nullptr, nullptr, &dataCount, &totalMetricCount, nullptr, nullptr);
+    ${t}MetricGroupCalculateMetricExportDataExp(hDriver, type, &exportDataSize, nullptr, nullptr, &dataCount, &totalMetricCount, nullptr, nullptr);
 
     // Allocate buffer for export data
     uint8_t* pExportData = malloc(exportDataSize);
 
     // Retrieve export data and data format
-    ${t}MetricGroupCalculateMetricExportDataExp (hDriver, type, &exportDataSize, pExportData, nullptr, &dataCount, &totalMetricCount, nullptr, nullptr);
+    ${t}MetricGroupCalculateMetricExportDataExp(hDriver, type, &exportDataSize, pExportData, nullptr, &dataCount, &totalMetricCount, nullptr, nullptr);
 
 
 The following code shows how to perform metrics calculation of collected data, which can be done in a different system than where data was collected.
@@ -57,12 +57,10 @@ The following code shows how to perform metrics calculation of collected data, w
     ${t}_metric_group_calculation_type_t type = ${T}_METRIC_GROUP_CALCULATION_TYPE_METRIC_VALUES;
     ${t}_metric_calculate_exp_desc_t calculateDesc;
     calculateDesc.rawReportSkipCount = 0;
-    ${t}MetricGroupCalculateMetricExportDataExp(hDriver, type, exportDataSize, pExportData, &calculateDesc,
-                        &dataCount, &totalMetricCount, nullptr, nullptr);
+    ${t}MetricGroupCalculateMetricExportDataExp(hDriver, type, exportDataSize, pExportData, &calculateDesc, &dataCount, &totalMetricCount, nullptr, nullptr);
 
     void* pMetricCounts = malloc(dataCount * sizeof(uint32_t));
     void* pMetricValues = malloc(totalMetricCount * sizeof(zet_typed_value_t));
 
     // Get metric counts and metric values
-    ${t}MetricGroupCalculateMetricExportDataExp(hDriver, type, exportDataSize, pExportData, &calculateDesc,
-                        &dataCount, &totalMetricCount, pMetricCounts, pMetricValues);
+    ${t}MetricGroupCalculateMetricExportDataExp(hDriver, type, exportDataSize, pExportData, &calculateDesc, &dataCount, &totalMetricCount, pMetricCounts, pMetricValues);

--- a/scripts/tools/GlobalTimestamps.yml
+++ b/scripts/tools/GlobalTimestamps.yml
@@ -39,7 +39,7 @@ members:
       name: timestampValidBits
       desc: "[out] Returns the number of valid bits in the timestamp value."
 details:
-    - "This structure may be returned from $tMetricGroupGetProperties via `pNext` member of $t_metric_group_properties_t"
+    - "This structure may be returned from $tMetricGroupGetProperties via the `pNext` member of $t_metric_group_properties_t."
     - "Used for mapping metric timestamps to other timers."
 --- #--------------------------------------------------------------------------
 type: function

--- a/scripts/tools/debug.yml
+++ b/scripts/tools/debug.yml
@@ -240,7 +240,7 @@ params:
       desc: |
             [in] if non-zero, then indicates the maximum time (in milliseconds) to yield before returning $X_RESULT_SUCCESS or $X_RESULT_NOT_READY;
             if zero, then immediately returns the status of the event;
-            if UINT64_MAX, then function will not return until complete or device is lost.
+            if `UINT64_MAX`, then function will not return until complete or device is lost.
             Due to external dependencies, timeout may be rounded to the closest value allowed by the accuracy of those dependencies.
     - type: "$t_debug_event_t*"
       name: event
@@ -474,10 +474,10 @@ params:
       desc: "[in] register set type"
     - type: uint32_t
       name: start
-      desc: "[in] the starting offset into the register state area; must be less than $t_debug_regset_properties_t.count for the type"
+      desc: "[in] the starting offset into the register state area; must be less than the `count` member of $t_debug_regset_properties_t for the type"
     - type: uint32_t
       name: count
-      desc: "[in] the number of registers to read; start+count must be <= zet_debug_register_group_properties_t.count for the type"
+      desc: "[in] the number of registers to read; start+count must be less than or equal to the `count` member of $t_debug_register_group_properties_t for the type"
     - type: "void*"
       name: pRegisterValues
       desc: "[in,out][optional][range(0, count)] buffer of register values"
@@ -501,10 +501,10 @@ params:
       desc: "[in] register set type"
     - type: uint32_t
       name: start
-      desc: "[in] the starting offset into the register state area; must be less than $t_debug_regset_properties_t.count for the type"
+      desc: "[in] the starting offset into the register state area; must be less than the `count` member of $t_debug_regset_properties_t for the type"
     - type: uint32_t
       name: count
-      desc: "[in] the number of registers to write; start+count must be <= zet_debug_register_group_properties_t.count for the type"
+      desc: "[in] the number of registers to write; start+count must be less than or equal to the `count` member of $t_debug_register_group_properties_t for the type"
     - type: "void*"
       name: pRegisterValues
       desc: "[in,out][optional][range(0, count)] buffer of register values"

--- a/scripts/tools/metric.yml
+++ b/scripts/tools/metric.yml
@@ -364,7 +364,7 @@ params:
       name: maxReportCount
       desc: |
             [in] the maximum number of reports the application wants to receive.
-            if UINT32_MAX, then function will retrieve all reports available
+            if `UINT32_MAX`, then function will retrieve all reports available
     - type: size_t*
       name: pRawDataSize
       desc: |
@@ -376,7 +376,7 @@ params:
       name: pRawData
       desc: "[in,out][optional][range(0, *pRawDataSize)] buffer containing streamer reports in raw format"
 returns:
-    - $X_RESULT_WARNING_DROPPED_DATA
+    - $X_RESULT_WARNING_DROPPED_DATA:
         - "Metric streamer data may have been dropped. Reduce sampling period."
 --- #--------------------------------------------------------------------------
 type: enum


### PR DESCRIPTION
Resolves #124 

- Update the helper script to better align doxygen comments.
- Use consistent language when referring to the pNext member of structures.
- Reduce script warnings by adjusting the language used to refer to struct members.
- Fix docs generation script to correctly handle etor errors.
- Remove (comment out) deprecated/unused Doxygen flags

Signed-off-by: Will Damon <will.damon@intel.com>