### PR TITLE
Add ray tracing acceleration structure build experimental extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ out/
 # IDE Files
 /.vscode
 /.devcontainer
+
+# Python Virtual Environment
+/.venv

--- a/scripts/core/EXT_Exp_RTASBuilder.rst
+++ b/scripts/core/EXT_Exp_RTASBuilder.rst
@@ -1,0 +1,347 @@
+<%
+import re
+from templates import helper as th
+%><%
+    OneApi=tags['$OneApi']
+    x=tags['$x']
+    X=x.upper()
+%>
+:orphan:
+
+.. _ZE_experimental_rtas_builder:
+
+======================================================
+ Ray Tracing Acceleration Structure Builder Extension
+======================================================
+
+API
+----
+
+* Enumerations
+
+
+    * ${x}_rtas_builder_exp_version_t
+    * ${x}_rtas_device_exp_flags_t
+    * ${x}_rtas_format_exp_t
+    * ${x}_rtas_builder_exp_flags_t
+    * ${x}_rtas_parallel_operation_exp_flags_t
+    * ${x}_rtas_builder_geometry_exp_flags_t
+    * ${x}_rtas_builder_instance_exp_flags_t
+    * ${x}_rtas_builder_build_op_exp_flags_t
+    * ${x}_rtas_builder_build_quality_hint_exp_t
+    * ${x}_rtas_builder_geometry_type_exp_t
+    * ${x}_rtas_builder_input_data_format_exp_t
+
+
+* Structures
+
+
+    * ${x}_rtas_builder_exp_desc_t
+
+    * ${x}_rtas_builder_exp_properties_t
+    * ${x}_rtas_parallel_operation_exp_properties_t
+    * ${x}_rtas_device_exp_properties_t
+
+    * ${x}_rtas_float3_exp_t
+    * ${x}_rtas_transform_float3x4_column_major_exp_t
+    * ${x}_rtas_transform_float3x4_aligned_column_major_exp_t
+    * ${x}_rtas_transform_float3x4_row_major_exp_t
+    * ${x}_rtas_aabb_exp_t
+    * ${x}_rtas_triangle_indices_uint32_exp_t
+    * ${x}_rtas_quad_indices_uint32_exp_t
+
+    * ${x}_rtas_builder_geometry_info_exp_t
+    * ${x}_rtas_builder_triangles_geometry_info_exp_t
+    * ${x}_rtas_builder_quads_geometry_info_exp_t
+    * ${x}_rtas_builder_procedural_geometry_info_exp_t
+    * ${x}_rtas_builder_instance_geometry_info_exp_t
+
+    * ${x}_rtas_builder_build_op_exp_desc_t
+
+
+* Functions
+
+
+    * ${x}RTASBuilderCreateExp
+    * ${x}RTASBuilderGetBuildPropertiesExp
+    * ${x}RTASBuilderBuildExp
+    * ${x}RTASBuilderDestroyExp
+
+    * ${x}DriverRTASFormatCompatibilityCheckExp
+
+    * ${x}RTASParallelOperationCreateExp
+    * ${x}RTASParallelOperationGetPropertiesExp
+    * ${x}RTASParallelOperationJoinExp
+    * ${x}RTASParallelOperationDestroyExp
+
+
+============================================
+ Ray Tracing Acceleration Structure Builder
+============================================
+
+The Ray Tracing Acceleration Structure Builder extension provides the functionality to build ray tracing acceleration structures (RTAS) for 3D scenes on the host for use with GPU devices.
+
+It is the user's responsibility to manage the acceleration structure buffer and scratch buffer resources. The required sizes may be queried via ${x}RTASBuilderGetBuildPropertiesExp. Once built, an acceleration structure is a self-contained entity; any input resources may be released after the successful construction. Note that acceleration structures are non-copyable resources.
+
+Scene Data
+-----------
+
+To build an acceleration structure, first setup a scene that consists of one or more geometry infos.
+
+    - ${x}_rtas_builder_triangles_geometry_info_exp_t for triangle meshes,
+    - ${x}_rtas_builder_quads_geometry_info_exp_t for quad meshes,
+    - ${x}_rtas_builder_procedural_geometry_info_exp_t for procedural primitives with attached axis-aligned bounding-box, and
+    - ${x}_rtas_builder_instance_geometry_info_exp_t for instances of other acceleration structures.
+
+The following example creates a ${x}_rtas_builder_triangles_geometry_info_exp_t to specify a triangle mesh:
+
+.. parsed-literal::
+
+        std::vector<${x}_rtas_triangle_indices_uint32_exp_t> triangleIndexBuffer;
+        std::vector<${x}_rtas_float3_exp_t> triangleVertexBuffer;
+
+        // Populate vertex and index buffers
+        {
+            // ...
+        }
+
+        ${x}_rtas_builder_triangles_geometry_info_exp_t mesh;
+        memset(&mesh, 0, sizeof(mesh));
+
+        mesh.geometryType = ${X}_RTAS_BUILDER_GEOMETRY_TYPE_EXP_TRIANGLES;
+        mesh.geometryFlags = 0;
+        mesh.geometryMask = 0xFF;
+
+        mesh.triangleFormat = ${X}_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_TRIANGLE_INDICES_UINT32;
+        mesh.triangleCount = triangleIndexBuffer.size();
+        mesh.triangleStride = sizeof(${x}_rtas_triangle_indices_uint32_exp_t);
+        mesh.pTriangleBuffer = triangleIndexBuffer.data();
+
+        mesh.vertexFormat = ${X}_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_FLOAT3;
+        mesh.vertexCount = triangleVertexBuffer.size();
+        mesh.vertexStride = sizeof(${x}_rtas_float3_exp_t);
+        mesh.pVertexBuffer = triangleVertexBuffer.data();
+
+Geometry is considered to be opaque by default, enabling a fast mode where traversal does not return to the caller of ray tracing for each triangle or quad hit. To process each triangle or quad hit by some any-hit shader, the `geometryFlags` member of the geometry infos must include the ${X}_RTAS_BUILDER_GEOMETRY_EXP_FLAG_NON_OPAQUE flag. The proper data formats of the triangle index- and vertex- buffers are specified, including the strides, and a pointer to the first element for each buffer.
+
+To refer to multiple geometries that make a scene, pointers to geometry info structures can be put into an array as follows:
+
+.. parsed-literal::
+
+        std::vector<${x}_rtas_builder_geometry_info_exp_t*> geometries;
+        geometries.push_back((${x}_rtas_builder_geometry_info_exp_t*)&mesh0);
+        geometries.push_back((${x}_rtas_builder_geometry_info_exp_t*)&mesh1);
+        ...
+
+This completes the definition of the geometry for the scene for which to construct the acceleration structure.
+
+Device Properties
+------------------
+
+The next step is to query the target device for acceleration structure properties.
+
+.. parsed-literal::
+
+        ${x}_rtas_device_exp_properties_t rtasDeviceProps;
+        rtasDeviceProps.stype = ${X}_STRUCTURE_TYPE_RTAS_DEVICE_EXP_PROPERTIES;
+        rtasDeviceProps.pNext = nullptr;
+
+        ${x}_device_properties_t deviceProps;
+        deviceProps.stype = ${X}_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+        deviceProps.pNext = &rtasDeviceProps;
+
+        ${x}DeviceGetProperties(hDevice, &deviceProps);
+
+
+The device properties contain information (a device-specific ray tracing acceleration structure format) that is required to complete an RTAS build operation.
+
+
+Acceleration Structure Builder
+-------------------------------
+
+With the scene data prepared and relevant device properties known, create a ray tracing acceleration structure builder object and query for the necessary build properties.
+
+.. parsed-literal::
+
+        ${x}_rtas_builder_exp_desc_t desc;
+        desc.stype = ${X}_STRUCTURE_TYPE_RTAS_BUILDER_EXP_DESC;
+        desc.pNext = nullptr;
+        desc.builderVersion = ${X}_RTAS_BUILDER_EXP_VERSION_CURRENT;
+
+        ${x}_rtas_builder_exp_handle_t hBuilder = nullptr;
+        ${x}_result_t result = ${x}RTASBuilderCreateExp(hDriver, &desc, &hBuilder);
+        assert(result == ${X}_RESULT_SUCCESS);
+
+        ${x}_rtas_builder_exp_properties_t builderProps;
+        builderProps.stype = ${X}_STRUCTURE_TYPE_RTAS_BUILDER_EXP_PROPERTIES;
+        builderProps.pNext = nullptr;
+
+        ${x}_rtas_builder_build_op_exp_desc_t buildOpDesc;
+        buildOpDesc.stype = ${X}_STRUCTURE_TYPE_RTAS_BUILDER_BUILD_OP_EXP_DESC;
+        buildOpDesc.pNext = nullptr;
+        buildOpDesc.rtasFormat = rtasDeviceProps.rtasFormat;
+        buildOpDesc.buildQuality = ${X}_RTAS_BUILDER_BUILD_QUALITY_HINT_EXP_MEDIUM;
+        buildOpDesc.buildFlags = 0;
+        buildOpDesc.ppGeometries = geometries.data();
+        buildOpDesc.numGeometries = geometries.size();
+
+        result = ${x}RTASBuilderGetBuildPropertiesExp(hBuilder, &buildOpDesc, &builderProps);
+        assert(result == ${X}_RESULT_SUCCESS);
+
+Note, the parameters of the build operation descriptor, such as acceleration structure build quality, affect the buffer requirements, etc.
+
+An application may create and use a single RTAS builder object, as multiple concurrent build operations may be performed with a single such object.
+
+Buffers
+--------
+
+With the builder properties along with everything else known at this point, the resources for the acceleration structure may be allocated.
+
+Scratch Buffer
+^^^^^^^^^^^^^^^
+
+A system memory scratch buffer is required to perform the build operation. It is used by the implementation for intermediate storage.
+
+.. parsed-literal::
+
+        void* pScratchBuffer = malloc(builderProps.scratchBufferSizeBytes);
+
+Acceleration Structure Buffer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The acceleration structure buffer is where the ray tracing acceleration structure is written to. It must be accessible on the host as well as the device; consequently, it must be allocated as a USM resource. This example uses the worst-case sizing.
+
+.. parsed-literal::
+
+        ${x}_raytracing_mem_alloc_ext_desc_t rtasMemAllocDesc;
+        rtasMemAllocDesc.stype = ${X}_STRUCTURE_TYPE_DEVICE_RAYTRACING_EXT_PROPERTIES;
+        rtasMemAllocDesc.pNext = nullptr;
+        rtasMemAllocDesc.flags = 0;
+
+        ${x}_device_mem_alloc_desc_t deviceMemAllocDesc;
+        deviceMemAllocDesc.stype = ${X}_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC;
+        deviceMemAllocDesc.pNext = &rtasMemAllocDesc;
+        deviceMemAllocDesc.flags = ${X}_DEVICE_MEM_ALLOC_FLAG_BIAS_CACHED;
+        deviceMemAllocDesc.ordinal = 0;
+
+        ${x}_host_mem_alloc_desc_t hostMemAllocDesc;
+        hostMemAllocDesc.stype = ${X}_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC;
+        hostMemAllocDesc.pNext = nullptr;
+        hostMemAllocDesc.flags = ${X}_HOST_MEM_ALLOC_FLAG_BIAS_CACHED;
+
+        void* pRtasBuffer = nullptr;
+        result = ${x}MemAllocShared(hContext, &deviceMemAllocDesc, &hostMemAllocDesc, builderProps.rtasBufferSizeBytesMaxRequired, rtasDeviceProps.rtasBufferAlignment, hDevice, &pRtasBuffer);
+        assert(result == ${X}_RESULT_SUCCESS);
+
+Executing an Acceleration Structure Build
+------------------------------------------
+
+Single-Threaded Build
+^^^^^^^^^^^^^^^^^^^^^^
+
+A single-threaded acceleration structure build on the host is initiated using ${x}RTASBuilderBuildExp.
+
+.. parsed-literal::
+
+        result = ${x}RTASBuilderBuildExp(hBuilder, &buildOpDesc, pScratchBuffer, builderProps.scratchBufferSizeBytes, pRtasBuffer, builderProps.rtasBufferSizeBytesMaxRequired, nullptr, nullptr, nullptr, nullptr);
+        assert(result == ${X}_RESULT_SUCCESS);
+
+When the build completes successfully the acceleration structure buffer is ready for use by the ray tracing API.
+
+Parallel Build
+^^^^^^^^^^^^^^^
+
+In order to speed up the build operation using multiple worker threads, a parallel operation object can be associated with the build operation and joined with the application-provided worker threads as in the following example:
+
+    **Note**
+    The following example uses `oneTBB <https://spec.oneapi.io/versions/latest/elements/oneTBB/source/nested-index.html>`_ to dispatch worker threads, but this is not a requirement.
+
+.. parsed-literal::
+
+        ${x}_rtas_parallel_operation_exp_handle_t hParallelOperation = nullptr;
+        result = ${x}RTASParallelOperationCreateExp(hDriver, &hParallelOperation);
+        assert(result == ${X}_RESULT_SUCCESS);
+
+        // Initiate the acceleration structure build operation with a handle
+        // of a parallel operation object. This causes the parallel operation to be
+        // bound to the build operation and the function returns immediately without
+        // building any acceleration structure yet.
+        result = ${x}RTASBuilderBuildExp(hBuilder, &buildOpDesc, pScratchBuffer, builderProps.scratchBufferSizeBytes, pRtasBuffer, builderProps.rtasBufferSizeBytesMaxRequired, hParallelOperation, nullptr, nullptr, nullptr);
+        assert(result == ${X}_RESULT_EXP_RTAS_BUILD_DEFERRED);
+
+        // Once the parallel operation is bound to the build operation the number
+        // of worker threads to join the parallel operation can be queried.
+        ${x}_rtas_parallel_operation_exp_properties_t parallelOpProps;
+        parallelOpProps.stype = ${X}_STRUCTURE_TYPE_RTAS_PARALLEL_OPERATION_EXP_PROPERTIES;
+        parallelOpProps.pNext = nullptr;
+
+        result = ${x}RTASParallelOperationGetPropertiesExp(hParallelOperation, &parallelOpProps);
+        assert(result == ${X}_RESULT_SUCCESS);
+
+        // Now worker threads can join the build operation to perform the actual build
+        // of the acceleration structure.
+        tbb::parallel_for(0, parallelOpProps.maxConcurrency, 1, [&](uint32_t i) {
+            ${x}_result_t buildResult = ${x}RTASParallelOperationJoinExp(hParallelOperation);
+            assert(buildResult == ${X}_RESULT_SUCCESS);
+        });
+
+        // With the parallel operation complete, the parallel operation object can be released.
+        result = ${x}RTASParallelOperationDestroyExp(hParallelOperation);
+        assert(result == ${X}_RESULT_SUCCESS);
+
+Note that the number of worker threads to be used can only be queried from the parallel operation object after it is bound to the build operation by the call to ${x}RTASBuilderBuildExp.
+
+
+Conservative Acceleration Structure Buffer Size
+------------------------------------------------
+
+Sizing the acceleration structure buffer using the `rtasBufferSizeBytesMaxRequired` member of ${x}_rtas_builder_exp_properties_t guarantees that the build operation will not fail due to an out-of-memory condition. However, this size represents the memory requirement for the worst-case scenario and is larger than is typically needed. To reduce memory usage, the application may attempt to execute a build using an acceleration structure buffer sized to the `rtasBufferSizeBytesExpected` member of ${x}_rtas_builder_exp_properties_t. When using the expected size, however, it is possible for the build operation to fail with ${X}_RESULT_EXP_RTAS_BUILD_RETRY. If this occurs, the application may resize the acceleration structure buffer with an updated size estimate provided by the builder build API.
+
+.. parsed-literal::
+
+        ${x}_result_t result;
+
+        void* pRtasBuffer = nullptr;
+        size_t rtasBufferSizeBytes = builderProps.rtasBufferSizeBytesExpected;
+
+        while (true)
+        {
+            pRtasBuffer = allocate_accel_buffer(rtasBufferSizeBytes);
+
+            result = ${x}RTASBuilderBuildExp(hBuilder, &buildOpDesc, pScratchBuffer, builderProps.scratchBufferSizeBytes, pRtasBuffer, rtasBufferSizeBytes, nullptr, nullptr, nullptr, &rtasBufferSizeBytes);
+
+            if (result == ${X}_RESULT_SUCCESS)
+            {
+                break;
+            }
+
+            assert(result == ${X}_RESULT_EXP_RTAS_BUILD_RETRY);
+
+            free_accel_buffer(pRtasBuffer);
+        }
+
+The loop starts with the minimum acceleration buffer size for which the build will mostly likely succeed. If the build runs out of memory, ${X}_RESULT_EXP_RTAS_BUILD_RETRY is returned and the build is retried with a larger acceleration structure buffer.
+
+The example above passes a pointer to the `rtasBufferSizeBytes` variable as a parameter to the build API, which it will update with a larger acceleration structure buffer size estimate to be used in the next attempt should the build operation fail. Alternatively, the application could increase the acceleration buffer size for the next attempt by some percentage, which could fail again, or just use the maximum size from the builder properties for the second attempt.
+
+Cleaning Up
+------------
+
+Once the acceleration structure has been built, any resources associated with the build may be released. Additionally, any parallel operation objects should be destroyed as well as any builder objects.
+
+.. parsed-literal::
+
+        // Free the scratch buffer
+        free(pScratchBuffer);
+
+        // Destroy the builder object
+        ${x}RTASBuilderDestroyExp(hBuilder);
+
+        // Use the acceleration structure buffer with the ray tracing API
+        {
+            // ...
+        }
+
+        // Release the acceleration structure buffer once it is no longer needed
+        ${x}MemFree(hContext, pRtasBuffer);
+        pRtasBuffer = nullptr;

--- a/scripts/core/RTASBuilder.yml
+++ b/scripts/core/RTASBuilder.yml
@@ -1,0 +1,959 @@
+#
+# Copyright (C) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+# See YaML.md for syntax definition
+#
+--- #--------------------------------------------------------------------------
+type: header
+desc: "Intel $OneApi Level-Zero Extension for supporting ray tracing acceleration structure builder."
+version: "1.7"
+--- #--------------------------------------------------------------------------
+type: macro
+desc: "Ray Tracing Acceleration Structure Builder Extension Name"
+version: "1.7"
+name: $X_RTAS_BUILDER_EXP_NAME
+value: '"$X_experimental_rtas_builder"'
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Ray Tracing Acceleration Structure Builder Extension Version(s)"
+version: "1.7"
+name: $x_rtas_builder_exp_version_t
+etors:
+    - name: "1_0"
+      value: "$X_MAKE_VERSION( 1, 0 )"
+      desc: "version 1.0"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Ray tracing acceleration structure device flags"
+version: "1.7"
+class: $xDevice
+name: $x_rtas_device_exp_flags_t
+etors:
+    - name: RESERVED
+      desc: "reserved for future use"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Ray tracing acceleration structure format"
+version: "1.7"
+class: $xDevice
+name: $x_rtas_format_exp_t
+etors:
+    - name: INVALID
+      desc: "Invalid acceleration structure format"
+details:
+    - "This is an opaque ray tracing acceleration structure format identifier."
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Ray tracing acceleration structure builder flags"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_exp_flags_t
+etors:
+    - name: RESERVED
+      desc: "Reserved for future use"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Ray tracing acceleration structure builder parallel operation flags"
+version: "1.7"
+class: $xRTASParallelOperation
+name: $x_rtas_parallel_operation_exp_flags_t
+etors:
+    - name: RESERVED
+      desc: "Reserved for future use"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Ray tracing acceleration structure builder geometry flags"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_geometry_exp_flags_t
+etors:
+    - name: NON_OPAQUE
+      desc: "non-opaque geometries invoke an any-hit shader"
+--- #--------------------------------------------------------------------------
+type: typedef
+desc: "Packed ray tracing acceleration structure builder geometry flags (see $x_rtas_builder_geometry_exp_flags_t)"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_packed_geometry_exp_flags_t
+value: uint8_t
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Ray tracing acceleration structure builder instance flags"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_instance_exp_flags_t
+etors:
+    - name: TRIANGLE_CULL_DISABLE
+      desc: "disables culling of front-facing and back-facing triangles"
+    - name: TRIANGLE_FRONT_COUNTERCLOCKWISE
+      desc: "reverses front and back face of triangles"
+    - name: TRIANGLE_FORCE_OPAQUE
+      desc: "forces instanced geometry to be opaque, unless ray flag forces it to be non-opaque"
+    - name: TRIANGLE_FORCE_NON_OPAQUE
+      desc: "forces instanced geometry to be non-opaque, unless ray flag forces it to be opaque"
+--- #--------------------------------------------------------------------------
+type: typedef
+desc: "Packed ray tracing acceleration structure builder instance flags (see $x_rtas_builder_instance_exp_flags_t)"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_packed_instance_exp_flags_t
+value: uint8_t
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Ray tracing acceleration structure builder build operation flags"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_build_op_exp_flags_t
+etors:
+    - name: COMPACT
+      desc: "build more compact acceleration structure"
+    - name: NO_DUPLICATE_ANYHIT_INVOCATION
+      desc: "guarantees single any-hit shader invocation per primitive"
+details:
+    - "These flags allow the application to tune the acceleration structure build operation."
+    - >
+      The acceleration structure builder implementation might choose to use spatial splitting to split large or long primitives into smaller pieces. This may result in any-hit shaders being invoked multiple times for non-opaque primitives, unless $X_RTAS_BUILDER_BUILD_OP_EXP_FLAG_NO_DUPLICATE_ANYHIT_INVOCATION is specified.
+    - "Usage of any of these flags may reduce ray tracing performance."
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Ray tracing acceleration structure builder build quality hint"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_build_quality_hint_exp_t
+etors:
+    - name: LOW
+      desc: "build low-quality acceleration structure (fast)"
+    - name: MEDIUM
+      desc: "build medium-quality acceleration structure (slower)"
+    - name: HIGH
+      desc: "build high-quality acceleration structure (slow)"
+details:
+    - "Depending on use case different quality modes for acceleration structure build are supported."
+    - >
+      A low-quality build builds an acceleration structure fast, but at the cost of some reduction in ray tracing performance. This mode is recommended for dynamic content, such as animated characters.
+    - >
+      A medium-quality build uses a compromise between build quality and ray tracing performance. This mode should be used by default.
+    - >
+      Higher ray tracing performance can be achieved by using a high-quality build, but acceleration structure build performance might be significantly reduced.
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Ray tracing acceleration structure builder geometry type"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_geometry_type_exp_t
+etors:
+    - name: TRIANGLES
+      desc: "triangle mesh geometry type"
+    - name: QUADS
+      desc: "quad mesh geometry type"
+    - name: PROCEDURAL
+      desc: "procedural geometry type"
+    - name: INSTANCE
+      desc: "instance geometry type"
+--- #--------------------------------------------------------------------------
+type: typedef
+desc: "Packed ray tracing acceleration structure builder geometry type (see $x_rtas_builder_geometry_type_exp_t)"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_packed_geometry_type_exp_t
+value: uint8_t
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Ray tracing acceleration structure data buffer element format"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_input_data_format_exp_t
+etors:
+    - name: FLOAT3
+      desc: "3-component float vector (see $x_rtas_float3_exp_t)"
+    - name: FLOAT3X4_COLUMN_MAJOR
+      desc: "3x4 affine transformation in column-major format (see $x_rtas_transform_float3x4_column_major_exp_t)"
+    - name: FLOAT3X4_ALIGNED_COLUMN_MAJOR
+      desc: "3x4 affine transformation in column-major format (see $x_rtas_transform_float3x4_aligned_column_major_exp_t)"
+    - name: FLOAT3X4_ROW_MAJOR
+      desc: "3x4 affine transformation in row-major format (see $x_rtas_transform_float3x4_row_major_exp_t)"
+    - name: AABB
+      desc: "3-dimensional axis-aligned bounding-box (see $x_rtas_aabb_exp_t)"
+    - name: TRIANGLE_INDICES_UINT32
+      desc: "Unsigned 32-bit triangle indices (see $x_rtas_triangle_indices_uint32_exp_t)"
+    - name: QUAD_INDICES_UINT32
+      desc: "Unsigned 32-bit quad indices (see $x_rtas_quad_indices_uint32_exp_t)"
+details:
+    - "Specifies the format of data buffer elements."
+    - "Data buffers may contain instancing transform matrices, triangle/quad vertex indices, etc..."
+--- #--------------------------------------------------------------------------
+type: typedef
+desc: "Packed ray tracing acceleration structure data buffer element format (see $x_rtas_builder_input_data_format_exp_t)"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_packed_input_data_format_exp_t
+value: uint8_t
+--- #--------------------------------------------------------------------------
+type: handle
+desc: "Handle of ray tracing acceleration structure builder object"
+version: "1.7"
+class: $xRTASBuilder
+name: "$x_rtas_builder_exp_handle_t"
+--- #--------------------------------------------------------------------------
+type: handle
+desc: "Handle of ray tracing acceleration structure builder parallel operation object"
+version: "1.7"
+class: $xRTASParallelOperation
+name: "$x_rtas_parallel_operation_exp_handle_t"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Ray tracing acceleration structure builder descriptor"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_exp_desc_t
+base: $x_base_desc_t
+members:
+    - type: $x_rtas_builder_exp_version_t
+      name: builderVersion
+      desc: "[in] ray tracing acceleration structure builder version"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Ray tracing acceleration structure builder properties"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_exp_properties_t
+base: $x_base_properties_t
+members:
+    - type: $x_rtas_builder_exp_flags_t
+      name: flags
+      desc: "[out] ray tracing acceleration structure builder flags"
+    - type: size_t
+      name: rtasBufferSizeBytesExpected
+      desc: |
+            [out] expected size (in bytes) required for acceleration structure buffer
+                - When using an acceleration structure buffer of this size, the build is expected to succeed; however, it is possible that the build may fail with $X_RESULT_EXP_RTAS_BUILD_RETRY
+    - type: size_t
+      name: rtasBufferSizeBytesMaxRequired
+      desc: |
+            [out] worst-case size (in bytes) required for acceleration structure buffer
+                - When using an acceleration structure buffer of this size, the build is guaranteed to not run out of memory.
+    - type: size_t
+      name: scratchBufferSizeBytes
+      desc: "[out] scratch buffer size (in bytes) required for acceleration structure build."
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Ray tracing acceleration structure builder parallel operation properties"
+version: "1.7"
+class: $xRTASParallelOperation
+name: $x_rtas_parallel_operation_exp_properties_t
+base: $x_base_properties_t
+members:
+    - type: $x_rtas_parallel_operation_exp_flags_t
+      name: flags
+      desc: "[out] ray tracing acceleration structure builder parallel operation flags"
+    - type: uint32_t
+      name: maxConcurrency
+      desc: "[out] maximum number of threads that may join the parallel operation"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Ray tracing acceleration structure device properties"
+version: "1.7"
+class: $xDevice
+name: $x_rtas_device_exp_properties_t
+base: $x_base_properties_t
+members:
+    - type: $x_rtas_device_exp_flags_t
+      name: flags
+      desc: "[out] ray tracing acceleration structure device flags"
+    - type: $x_rtas_format_exp_t
+      name: rtasFormat
+      desc: "[out] ray tracing acceleration structure format"
+    - type: uint32_t
+      name: rtasBufferAlignment
+      desc: "[out] required alignment of acceleration structure buffer"
+details:
+    - "This structure may be passed to $xDeviceGetProperties, via `pNext` member of $x_device_properties_t."
+    - "The implementation shall populate `format` with a value other than $X_RTAS_FORMAT_EXP_INVALID when the device supports ray tracing."
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "A 3-component vector type"
+version: "1.7"
+name: $x_rtas_float3_exp_t
+members:
+    - type: float
+      name: x
+      desc: "[in] x-coordinate of float3 vector"
+    - type: float
+      name: y
+      desc: "[in] y-coordinate of float3 vector"
+    - type: float
+      name: z
+      desc: "[in] z-coordinate of float3 vector"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "3x4 affine transformation in column-major layout"
+version: "1.7"
+name: $x_rtas_transform_float3x4_column_major_exp_t
+members:
+    - type: float
+      name: vx_x
+      desc: "[in] element 0 of column 0 of 3x4 matrix"
+    - type: float
+      name: vx_y
+      desc: "[in] element 1 of column 0 of 3x4 matrix"
+    - type: float
+      name: vx_z
+      desc: "[in] element 2 of column 0 of 3x4 matrix"
+    - type: float
+      name: vy_x
+      desc: "[in] element 0 of column 1 of 3x4 matrix"
+    - type: float
+      name: vy_y
+      desc: "[in] element 1 of column 1 of 3x4 matrix"
+    - type: float
+      name: vy_z
+      desc: "[in] element 2 of column 1 of 3x4 matrix"
+    - type: float
+      name: vz_x
+      desc: "[in] element 0 of column 2 of 3x4 matrix"
+    - type: float
+      name: vz_y
+      desc: "[in] element 1 of column 2 of 3x4 matrix"
+    - type: float
+      name: vz_z
+      desc: "[in] element 2 of column 2 of 3x4 matrix"
+    - type: float
+      name: p_x
+      desc: "[in] element 0 of column 3 of 3x4 matrix"
+    - type: float
+      name: p_y
+      desc: "[in] element 1 of column 3 of 3x4 matrix"
+    - type: float
+      name: p_z
+      desc: "[in] element 2 of column 3 of 3x4 matrix"
+details:
+    - |
+      A 3x4 affine transformation in column major layout, consisting of vectors
+          - vx=(vx_x, vx_y, vx_z),
+          - vy=(vy_x, vy_y, vy_z),
+          - vz=(vz_x, vz_y, vz_z), and
+          - p=(p_x, p_y, p_z)
+    - "The transformation transforms a point (x, y, z) to: `x*vx + y*vy + z*vz + p`."
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "3x4 affine transformation in column-major layout with aligned column vectors"
+version: "1.7"
+name: $x_rtas_transform_float3x4_aligned_column_major_exp_t
+members:
+    - type: float
+      name: vx_x
+      desc: "[in] element 0 of column 0 of 3x4 matrix"
+    - type: float
+      name: vx_y
+      desc: "[in] element 1 of column 0 of 3x4 matrix"
+    - type: float
+      name: vx_z
+      desc: "[in] element 2 of column 0 of 3x4 matrix"
+    - type: float
+      name: pad0
+      desc: "[in] ignored padding"
+    - type: float
+      name: vy_x
+      desc: "[in] element 0 of column 1 of 3x4 matrix"
+    - type: float
+      name: vy_y
+      desc: "[in] element 1 of column 1 of 3x4 matrix"
+    - type: float
+      name: vy_z
+      desc: "[in] element 2 of column 1 of 3x4 matrix"
+    - type: float
+      name: pad1
+      desc: "[in] ignored padding"
+    - type: float
+      name: vz_x
+      desc: "[in] element 0 of column 2 of 3x4 matrix"
+    - type: float
+      name: vz_y
+      desc: "[in] element 1 of column 2 of 3x4 matrix"
+    - type: float
+      name: vz_z
+      desc: "[in] element 2 of column 2 of 3x4 matrix"
+    - type: float
+      name: pad2
+      desc: "[in] ignored padding"
+    - type: float
+      name: p_x
+      desc: "[in] element 0 of column 3 of 3x4 matrix"
+    - type: float
+      name: p_y
+      desc: "[in] element 1 of column 3 of 3x4 matrix"
+    - type: float
+      name: p_z
+      desc: "[in] element 2 of column 3 of 3x4 matrix"
+    - type: float
+      name: pad3
+      desc: "[in] ignored padding"
+details:
+    - |
+      A 3x4 affine transformation in column major layout, consisting of vectors
+        - vx=(vx_x, vx_y, vx_z),
+        - vy=(vy_x, vy_y, vy_z),
+        - vz=(vz_x, vz_y, vz_z), and
+        - p=(p_x, p_y, p_z)
+    - "The transformation transforms a point (x, y, z) to: `x*vx + y*vy + z*vz + p`."
+    - "The column vectors are aligned to 16-bytes and pad members are ignored."
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "3x4 affine transformation in row-major layout"
+version: "1.7"
+name: $x_rtas_transform_float3x4_row_major_exp_t
+members:
+    - type: float
+      name: vx_x
+      desc: "[in] element 0 of row 0 of 3x4 matrix"
+    - type: float
+      name: vy_x
+      desc: "[in] element 1 of row 0 of 3x4 matrix"
+    - type: float
+      name: vz_x
+      desc: "[in] element 2 of row 0 of 3x4 matrix"
+    - type: float
+      name: p_x
+      desc: "[in] element 3 of row 0 of 3x4 matrix"
+    - type: float
+      name: vx_y
+      desc: "[in] element 0 of row 1 of 3x4 matrix"
+    - type: float
+      name: vy_y
+      desc: "[in] element 1 of row 1 of 3x4 matrix"
+    - type: float
+      name: vz_y
+      desc: "[in] element 2 of row 1 of 3x4 matrix"
+    - type: float
+      name: p_y
+      desc: "[in] element 3 of row 1 of 3x4 matrix"
+    - type: float
+      name: vx_z
+      desc: "[in] element 0 of row 2 of 3x4 matrix"
+    - type: float
+      name: vy_z
+      desc: "[in] element 1 of row 2 of 3x4 matrix"
+    - type: float
+      name: vz_z
+      desc: "[in] element 2 of row 2 of 3x4 matrix"
+    - type: float
+      name: p_z
+      desc: "[in] element 3 of row 2 of 3x4 matrix"
+details:
+    - |
+      A 3x4 affine transformation in row-major layout, consisting of vectors
+          - vx=(vx_x, vx_y, vx_z),
+          - vy=(vy_x, vy_y, vy_z),
+          - vz=(vz_x, vz_y, vz_z), and
+          - p=(p_x, p_y, p_z)
+    - "The transformation transforms a point (x, y, z) to: `x*vx + y*vy + z*vz + p`."
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "A 3-dimensional axis-aligned bounding-box with lower and upper bounds in each dimension"
+version: "1.7"
+name: $x_rtas_aabb_exp_t
+members:
+    - type: $x_rtas_float3_exp_t
+      name: lower
+      desc: "[in] lower bounds of AABB"
+    - type: $x_rtas_float3_exp_t
+      name: upper
+      desc: "[in] upper bounds of AABB"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Triangle represented using 3 vertex indices"
+version: "1.7"
+name: $x_rtas_triangle_indices_uint32_exp_t
+members:
+    - type: uint32_t
+      name: v0
+      desc: "[in] first index pointing to the first triangle vertex in vertex array"
+    - type: uint32_t
+      name: v1
+      desc: "[in] second index pointing to the second triangle vertex in vertex array"
+    - type: uint32_t
+      name: v2
+      desc: "[in] third index pointing to the third triangle vertex in vertex array"
+details:
+    - "Represents a triangle using 3 vertex indices that index into a vertex array that needs to be provided together with the index array."
+    - |
+      The linear barycentric u/v parametrization of the triangle is defined as:
+          - (u=0, v=0) at v0,
+          - (u=1, v=0) at v1, and
+          - (u=0, v=1) at v2
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Quad represented using 4 vertex indices"
+version: "1.7"
+name: $x_rtas_quad_indices_uint32_exp_t
+members:
+    - type: uint32_t
+      name: v0
+      desc: "[in] first index pointing to the first quad vertex in vertex array"
+    - type: uint32_t
+      name: v1
+      desc: "[in] second index pointing to the second quad vertex in vertex array"
+    - type: uint32_t
+      name: v2
+      desc: "[in] third index pointing to the third quad vertex in vertex array"
+    - type: uint32_t
+      name: v3
+      desc: "[in] fourth index pointing to the fourth quad vertex in vertex array"
+details:
+    - "Represents a quad composed of 4 indices that index into a vertex array that needs to be provided together with the index array."
+    - |
+      A quad is a triangle pair represented using 4 vertex indices v0, v1, v2, v3.
+      The first triangle is made out of indices v0, v1, v3 and the second triangle
+      from indices v2, v3, v1. The piecewise linear barycentric u/v parametrization
+      of the quad is defined as:
+          - (u=0, v=0) at v0,
+          - (u=1, v=0) at v1,
+          - (u=0, v=1) at v3, and
+          - (u=1, v=1) at v2
+      This is achieved by correcting the u'/v' coordinates of the second triangle by
+      *u = 1-u'* and *v = 1-v'*, yielding a piecewise linear parametrization.
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Ray tracing acceleration structure builder geometry info"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_geometry_info_exp_t
+members:
+    - type: $x_rtas_builder_packed_geometry_type_exp_t
+      name: geometryType
+      desc: "[in] geometry type"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Ray tracing acceleration structure builder triangle mesh geometry info"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_triangles_geometry_info_exp_t
+members:
+    - type: $x_rtas_builder_packed_geometry_type_exp_t
+      name: geometryType
+      desc: "[in] geometry type, must be $X_RTAS_BUILDER_GEOMETRY_TYPE_EXP_TRIANGLES"
+    - type: $x_rtas_builder_packed_geometry_exp_flags_t
+      name: geometryFlags
+      desc: "[in] 0 or some combination of $x_rtas_builder_geometry_exp_flag_t bits representing the geometry flags for all primitives of this geometry"
+    - type: uint8_t
+      name: geometryMask
+      desc: "[in] 8-bit geometry mask for ray masking"
+    - type: $x_rtas_builder_packed_input_data_format_exp_t
+      name: triangleFormat
+      desc: "[in] format of triangle buffer data, must be $X_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_TRIANGLE_INDICES_UINT32"
+    - type: $x_rtas_builder_packed_input_data_format_exp_t
+      name: vertexFormat
+      desc: "[in] format of vertex buffer data, must be $X_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_FLOAT3"
+    - type: uint32_t
+      name: triangleCount
+      desc: "[in] number of triangles in triangle buffer"
+    - type: uint32_t
+      name: vertexCount
+      desc: "[in] number of vertices in vertex buffer"
+    - type: uint32_t
+      name: triangleStride
+      desc: "[in] stride (in bytes) of triangles in triangle buffer"
+    - type: uint32_t
+      name: vertexStride
+      desc: "[in] stride (in bytes) of vertices in vertex buffer"
+    - type: void*
+      name: pTriangleBuffer
+      desc: "[in] pointer to array of triangle indices in specified format"
+    - type: void*
+      name: pVertexBuffer
+      desc: "[in] pointer to array of triangle vertices in specified format"
+details:
+    - |
+      The linear barycentric u/v parametrization of the triangle is defined as:
+          - (u=0, v=0) at v0,
+          - (u=1, v=0) at v1, and
+          - (u=0, v=1) at v2
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Ray tracing acceleration structure builder quad mesh geometry info"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_quads_geometry_info_exp_t
+members:
+    - type: $x_rtas_builder_packed_geometry_type_exp_t
+      name: geometryType
+      desc: "[in] geometry type, must be $X_RTAS_BUILDER_GEOMETRY_TYPE_EXP_QUADS"
+    - type: $x_rtas_builder_packed_geometry_exp_flags_t
+      name: geometryFlags
+      desc: "[in] 0 or some combination of $x_rtas_builder_geometry_exp_flag_t bits representing the geometry flags for all primitives of this geometry"
+    - type: uint8_t
+      name: geometryMask
+      desc: "[in] 8-bit geometry mask for ray masking"
+    - type: $x_rtas_builder_packed_input_data_format_exp_t
+      name: quadFormat
+      desc: "[in] format of quad buffer data, must be $X_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_QUAD_INDICES_UINT32"
+    - type: $x_rtas_builder_packed_input_data_format_exp_t
+      name: vertexFormat
+      desc: "[in] format of vertex buffer data, must be $X_RTAS_BUILDER_INPUT_DATA_FORMAT_EXP_FLOAT3"
+    - type: uint32_t
+      name: quadCount
+      desc: "[in] number of quads in quad buffer"
+    - type: uint32_t
+      name: vertexCount
+      desc: "[in] number of vertices in vertex buffer"
+    - type: uint32_t
+      name: quadStride
+      desc: "[in] stride (in bytes) of quads in quad buffer"
+    - type: uint32_t
+      name: vertexStride
+      desc: "[in] stride (in bytes) of vertices in vertex buffer"
+    - type: void*
+      name: pQuadBuffer
+      desc: "[in] pointer to array of quad indices in specified format"
+    - type: void*
+      name: pVertexBuffer
+      desc: "[in] pointer to array of quad vertices in specified format"
+details:
+    - |
+      A quad is a triangle pair represented using 4 vertex indices v0, v1, v2, v3.
+      The first triangle is made out of indices v0, v1, v3 and the second triangle
+      from indices v2, v3, v1. The piecewise linear barycentric u/v parametrization
+      of the quad is defined as:
+          - (u=0, v=0) at v0,
+          - (u=1, v=0) at v1,
+          - (u=0, v=1) at v3, and
+          - (u=1, v=1) at v2
+      This is achieved by correcting the u'/v' coordinates of the second triangle by
+      *u = 1-u'* and *v = 1-v'*, yielding a piecewise linear parametrization.
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "AABB callback function parameters"
+version: "1.7"
+name: $x_rtas_geometry_aabbs_exp_cb_params_t
+base: $x_base_cb_params_t
+members:
+    - type: uint32_t
+      name: primID
+      desc: "[in] first primitive to return bounds for"
+    - type: uint32_t
+      name: primIDCount
+      desc: "[in] number of primitives to return bounds for"
+    - type: void*
+      name: pGeomUserPtr
+      desc: "[in] pointer provided through geometry descriptor"
+    - type: void*
+      name: pBuildUserPtr
+      desc: "[in] pointer provided through $xRTASBuilderBuildExp function"
+    - type: $x_rtas_aabb_exp_t*
+      name: pBoundsOut
+      desc: "[out] destination buffer to write AABB bounds to"
+--- #--------------------------------------------------------------------------
+type: callback
+desc: "Callback function pointer type to return AABBs for a range of procedural primitives"
+version: "1.7"
+name: $x_rtas_geometry_aabbs_cb_exp_t
+returntype: void
+params:
+    - type: $x_rtas_geometry_aabbs_exp_cb_params_t*
+      name: params
+      desc: "[in] callback function parameters structure"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Ray tracing acceleration structure builder procedural primitives geometry info"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_procedural_geometry_info_exp_t
+members:
+    - type: $x_rtas_builder_packed_geometry_type_exp_t
+      name: geometryType
+      desc: "[in] geometry type, must be $X_RTAS_BUILDER_GEOMETRY_TYPE_EXP_PROCEDURAL"
+    - type: $x_rtas_builder_packed_geometry_exp_flags_t
+      name: geometryFlags
+      desc: "[in] 0 or some combination of $x_rtas_builder_geometry_exp_flag_t bits representing the geometry flags for all primitives of this geometry"
+    - type: uint8_t
+      name: geometryMask
+      desc: "[in] 8-bit geometry mask for ray masking"
+    - type: uint8_t
+      name: reserved
+      desc: "[in] reserved for future use"
+    - type: uint32_t
+      name: primCount
+      desc: "[in] number of primitives in geometry"
+    - type: $x_rtas_geometry_aabbs_cb_exp_t
+      name: pfnGetBoundsCb
+      desc: "[in] pointer to callback function to get the axis-aligned bounding-box for a range of primitives"
+    - type: void*
+      name: pGeomUserPtr
+      desc: "[in] user data pointer passed to callback"
+details:
+    - |
+      A host-side bounds callback function is invoked by the acceleration structure builder to query the bounds of procedural primitives on demand. The callback is passed some `pGeomUserPtr` that can point to an application-side representation of the procedural primitives. Further, a second `pBuildUserPtr`, which is set by a parameter to $xRTASBuilderBuildExp, is passed to the callback. This allows the build to change the bounds of the procedural geometry, for example, to build a BVH only over a short time range to implement multi-segment motion blur.
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Ray tracing acceleration structure builder instance geometry info"
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_instance_geometry_info_exp_t
+members:
+    - type: $x_rtas_builder_packed_geometry_type_exp_t
+      name: geometryType
+      desc: "[in] geometry type, must be $X_RTAS_BUILDER_GEOMETRY_TYPE_EXP_INSTANCE"
+    - type: $x_rtas_builder_packed_instance_exp_flags_t
+      name: instanceFlags
+      desc: "[in] 0 or some combination of $x_rtas_builder_geometry_exp_flag_t bits representing the geometry flags for all primitives of this geometry"
+    - type: uint8_t
+      name: geometryMask
+      desc: "[in] 8-bit geometry mask for ray masking"
+    - type: $x_rtas_builder_packed_input_data_format_exp_t
+      name: transformFormat
+      desc: "[in] format of the specified transformation"
+    - type: uint32_t
+      name: instanceUserID
+      desc: "[in] user-specified identifier for the instance"
+    - type: void*
+      name: pTransform
+      desc: "[in] object-to-world instance transformation in specified format"
+    - type: $x_rtas_aabb_exp_t*
+      name: pBounds
+      desc: "[in] object-space axis-aligned bounding-box of the instanced acceleration structure"
+    - type: void*
+      name: pAccelerationStructure
+      desc: "[in] pointer to acceleration structure to instantiate"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: ""
+version: "1.7"
+class: $xRTASBuilder
+name: $x_rtas_builder_build_op_exp_desc_t
+base: $x_base_desc_t
+members:
+    - type: $x_rtas_format_exp_t
+      name: rtasFormat
+      desc: "[in] ray tracing acceleration structure format"
+    - type: $x_rtas_builder_build_quality_hint_exp_t
+      name: buildQuality
+      desc: "[in] acceleration structure build quality hint"
+    - type: $x_rtas_builder_build_op_exp_flags_t
+      name: buildFlags
+      desc: "[in] 0 or some combination of $x_rtas_builder_build_op_exp_flag_t flags"
+    - type: const $x_rtas_builder_geometry_info_exp_t**
+      name: ppGeometries
+      desc: "[in][optional][range(0, `numGeometries`)] NULL or a valid array of pointers to geometry infos"
+    - type: uint32_t
+      name: numGeometries
+      desc: "[in] number of geometries in geometry infos array, can be zero when `ppGeometries` is NULL"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Creates a ray tracing acceleration structure builder object"
+version: "1.7"
+class: $xRTASBuilder
+name: CreateExp
+params:
+    - type: $x_driver_handle_t
+      name: hDriver
+      desc: "[in] handle of driver object"
+    - type: const $x_rtas_builder_exp_desc_t*
+      name: pDescriptor
+      desc: "[in] pointer to builder descriptor"
+    - type: $x_rtas_builder_exp_handle_t*
+      name: phBuilder
+      desc: "[out] handle of builder object"
+details:
+    - "The application may call this function from simultaneous threads."
+    - "The implementation of this function must be thread-safe."
+    - "The implementation must support $X_experimental_rtas_builder extension."
+results:
+    - $X_RESULT_ERROR_DEPENDENCY_UNAVAILABLE:
+        - "Runtime dependency failed to load"
+    - $X_RESULT_ERROR_UNSUPPORTED_VERSION:
+        - "Requested version passed in via descriptor is unavailable or not supported by driver"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Retrieves ray tracing acceleration structure builder properties"
+version: "1.7"
+class: $xRTASBuilder
+name: GetBuildPropertiesExp
+params:
+    - type: $x_rtas_builder_exp_handle_t
+      name: hBuilder
+      desc: "[in] handle of builder object"
+    - type: const $x_rtas_builder_build_op_exp_desc_t*
+      name: pBuildOpDescriptor
+      desc: "[in] pointer to build operation descriptor"
+    - type: $x_rtas_builder_exp_properties_t*
+      name: pProperties
+      desc: "[in,out] query result for builder properties"
+details:
+    - "The application may call this function from simultaneous threads."
+    - "The implementation of this function must be thread-safe."
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Checks ray tracing acceleration structure format compatibility"
+version: "1.7"
+class: $xDriver
+name: RTASFormatCompatibilityCheckExp
+params:
+    - type: $x_driver_handle_t
+      name: hDriver
+      desc: "[in] handle of driver object"
+    - type: $x_rtas_format_exp_t
+      name: rtasFormatA
+      desc: "[in] operand A"
+    - type: $x_rtas_format_exp_t
+      name: rtasFormatB
+      desc: "[in] operand B"
+details:
+    - "The application may call this function from simultaneous threads."
+    - "The implementation of this function must be thread-safe."
+returns:
+    - $X_RESULT_SUCCESS:
+        - "An acceleration structure built with `rtasFormatA` is compatible with devices that report `rtasFormatB`."
+    - $X_RESULT_EXP_ERROR_OPERANDS_INCOMPATIBLE:
+        - "An acceleration structure built with `rtasFormatA` is **not** compatible with devices that report `rtasFormatB`."
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Build ray tracing acceleration structure"
+version: "1.7"
+class: $xRTASBuilder
+name: BuildExp
+params:
+    - type: $x_rtas_builder_exp_handle_t
+      name: hBuilder
+      desc: "[in] handle of builder object"
+    - type: const $x_rtas_builder_build_op_exp_desc_t*
+      name: pBuildOpDescriptor
+      desc: "[in] pointer to build operation descriptor"
+    - type: void*
+      name: pScratchBuffer
+      desc: "[in][range(0, `scratchBufferSizeBytes`)] scratch buffer to be used during acceleration structure construction"
+    - type: size_t
+      name: scratchBufferSizeBytes
+      desc: "[in] size of scratch buffer, in bytes"
+    - type: void*
+      name: pRtasBuffer
+      desc: "[in] pointer to destination buffer"
+    - type: size_t
+      name: rtasBufferSizeBytes
+      desc: "[in] destination buffer size, in bytes"
+    - type: $x_rtas_parallel_operation_exp_handle_t
+      name: hParallelOperation
+      desc: "[in][optional] handle to parallel operation object"
+    - type: void*
+      name: pBuildUserPtr
+      desc: "[in][optional] pointer passed to callbacks"
+    - type: $x_rtas_aabb_exp_t*
+      name: pBounds
+      desc: "[in,out][optional] pointer to destination address for acceleration structure bounds"
+    - type: size_t*
+      name: pRtasBufferSizeBytes
+      desc: "[out][optional] updated acceleration structure size requirement, in bytes"
+details:
+    - >
+      This function builds an acceleration structure of the scene consisting of the specified geometry information and writes the acceleration structure to the provided destination buffer. All types of geometries can get freely mixed inside a scene.
+    - >
+      It is the user's responsibility to manage the acceleration structure buffer allocation, de-allocation, and potential prefetching to the device memory. The required size of the acceleration structure buffer can be queried with the $xRTASBuilderGetBuildPropertiesExp function. The acceleration structure buffer must be a shared USM allocation and should be present on the host at build time. The referenced scene data (index- and vertex- buffers) can be standard host allocations, and will not be referenced into by the build acceleration structure.
+    - >
+      Before an acceleration structure can be built, the user must allocate the memory for the acceleration structure buffer and scratch buffer using sizes based on a query for the estimated size properties.
+    - >
+      When using the "worst-case" size for the acceleration structure buffer, the acceleration structure construction will never fail with $X_RESULT_EXP_RTAS_BUILD_RETRY.
+    - >
+      When using the "expected" size for the acceleration structure buffer, the acceleration structure construction may fail with $X_RESULT_EXP_RTAS_BUILD_RETRY. If this happens, the user may resize their acceleration structure buffer using the returned `*pRtasBufferSizeBytes` value, which will be updated with an improved size estimate that will likely result in a successful build.
+    - >
+      The acceleration structure construction is run on the host and is synchronous, thus after the function returns with a successful result, the acceleration structure may be used.
+    - >
+      All provided data buffers must be host-accessible.
+    - >
+      The acceleration structure buffer must be a USM allocation.
+    - >
+      A successfully constructed acceleration structure is entirely self-contained. There is no requirement for input data to persist beyond build completion.
+    - >
+      A successfully constructed acceleration structure is non-copyable.
+    - >
+      Acceleration structure construction may be parallelized by passing a valid handle to a parallel operation object and joining that parallel operation using $xRTASParallelOperationJoinExp with user-provided worker threads.
+
+    - |
+      **Additional Notes**
+        - "The geometry infos array, geometry infos, and scratch buffer must all be standard host memory allocations."
+        - "A pointer to a geometry info can be a null pointer, in which case the geometry is treated as empty."
+        - "If no parallel operation handle is provided, the build is run sequentially on the current thread."
+        - "A parallel operation object may only be associated with a single acceleration structure build at a time."
+returns:
+    - $X_RESULT_EXP_RTAS_BUILD_DEFERRED:
+        - "Acceleration structure build completion is deferred to parallel operation join."
+    - $X_RESULT_EXP_RTAS_BUILD_RETRY:
+        - "Acceleration structure build failed due to insufficient resources, retry the build operation with a larger acceleration structure buffer allocation."
+    - $X_RESULT_ERROR_HANDLE_OBJECT_IN_USE:
+        - "Acceleration structure build failed due to parallel operation object participation in another build operation."
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Destroys a ray tracing acceleration structure builder object"
+version: "1.7"
+class: $xRTASBuilder
+name: DestroyExp
+params:
+    - type: $x_rtas_builder_exp_handle_t
+      name: hBuilder
+      desc: "[in][release] handle of builder object to destroy"
+details:
+    - "The implementation of this function may immediately release any internal Host and Device resources associated with this builder."
+    - "The application must **not** call this function from simultaneous threads with the same builder handle."
+    - "The implementation of this function must be thread-safe."
+returns:
+    - $X_RESULT_ERROR_HANDLE_OBJECT_IN_USE
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Creates a ray tracing acceleration structure builder parallel operation object"
+version: "1.7"
+class: $xRTASParallelOperation
+name: CreateExp
+params:
+    - type: $x_driver_handle_t
+      name: hDriver
+      desc: "[in] handle of driver object"
+    - type: $x_rtas_parallel_operation_exp_handle_t*
+      name: phParallelOperation
+      desc: "[out] handle of parallel operation object"
+details:
+    - "The application may call this function from simultaneous threads."
+    - "The implementation of this function must be thread-safe."
+    - "The implementation must support $X_experimental_rtas_builder extension."
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Retrieves ray tracing acceleration structure builder parallel operation properties"
+version: "1.7"
+class: $xRTASParallelOperation
+name: GetPropertiesExp
+params:
+    - type: $x_rtas_parallel_operation_exp_handle_t
+      name: hParallelOperation
+      desc: "[in] handle of parallel operation object"
+    - type: $x_rtas_parallel_operation_exp_properties_t*
+      name: pProperties
+      desc: "[in,out] query result for parallel operation properties"
+details:
+    - "The application must first bind the parallel operation object to a build operation before it may query the parallel operation properties. In other words, the application must first call $xRTASBuilderBuildExp with **hParallelOperation** before calling this function."
+    - "The application may call this function from simultaneous threads."
+    - "The implementation of this function must be thread-safe."
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Joins a parallel build operation"
+version: "1.7"
+class: $xRTASParallelOperation
+name: JoinExp
+params:
+    - type: $x_rtas_parallel_operation_exp_handle_t
+      name: hParallelOperation
+      desc: "[in] handle of parallel operation object"
+details:
+    - "All worker threads return the same error code for the parallel build operation upon build completion"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Destroys a ray tracing acceleration structure builder parallel operation object"
+version: "1.7"
+class: $xRTASParallelOperation
+name: DestroyExp
+params:
+    - type: $x_rtas_parallel_operation_exp_handle_t
+      name: hParallelOperation
+      desc: "[in][release] handle of parallel operation object to destroy"
+details:
+    - "The implementation of this function may immediately release any internal Host and Device resources associated with this parallel operation."
+    - "The application must **not** call this function from simultaneous threads with the same parallel operation handle."
+    - "The implementation of this function must be thread-safe."

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -205,17 +205,24 @@ etors:
       desc: "[Core] device currently in low power state"
       version: "1.2"
     - name: EXP_ERROR_DEVICE_IS_NOT_VERTEX
-      desc: "[Core, Expoerimental] device is not represented by a fabric vertex"
+      desc: "[Core, Experimental] device is not represented by a fabric vertex"
       version: "1.4"
       value: "0x7ff00001"
     - name: EXP_ERROR_VERTEX_IS_NOT_DEVICE
       desc: "[Core, Experimental] fabric vertex does not represent a device"
       version: "1.4"
-      value: "0x7ff00002"
     - name: EXP_ERROR_REMOTE_DEVICE
-      desc: "[Core, Expoerimental] fabric vertex represents a remote device or subdevice"
+      desc: "[Core, Experimental] fabric vertex represents a remote device or subdevice"
       version: "1.4"
-      value: "0x7ff00003"
+    - name: EXP_ERROR_OPERANDS_INCOMPATIBLE
+      desc: "[Core, Experimental] operands of comparison are not compatible"
+      version: "1.7"
+    - name: EXP_RTAS_BUILD_RETRY
+      desc: "[Core, Experimental] ray tracing acceleration structure build operation failed due to insufficient resources, retry with a larger acceleration structure buffer allocation"
+      version: "1.7"
+    - name: EXP_RTAS_BUILD_DEFERRED
+      desc: "[Core, Experimental] ray tracing acceleration structure build operation deferred to parallel operation join"
+      version: "1.7"
     - name: ERROR_INSUFFICIENT_PERMISSIONS
       value: "0x70010000"
       desc: "[Sysman] access denied due to permission level"
@@ -223,8 +230,11 @@ etors:
       desc: "[Sysman] resource already in use and simultaneous access not allowed or resource was removed"
     - name: ERROR_DEPENDENCY_UNAVAILABLE
       value: "0x70020000"
-      desc: "[Tools] external required dependency is unavailable or missing"
+      desc:
+            "1.6": "[Tools] external required dependency is unavailable or missing"
+            "1.7": "[Common] external required dependency is unavailable or missing"
     - name: WARNING_DROPPED_DATA
+      value: "0x70020001"
       desc: "[Tools] data may have been dropped"
       version: "1.4"
     - name: ERROR_UNINITIALIZED
@@ -471,6 +481,30 @@ etors:
       desc: $x_memory_sub_allocations_exp_properties_t
       version: "1.5"
       value: "0x0002000D"
+    - name: RTAS_BUILDER_EXP_DESC
+      desc: $x_rtas_builder_exp_desc_t
+      version: "1.7"
+      value: "0x0002000E"
+    - name: RTAS_BUILDER_BUILD_OP_EXP_DESC
+      desc: $x_rtas_builder_build_op_exp_desc_t
+      version: "1.7"
+      value: "0x0002000F"
+    - name: RTAS_BUILDER_EXP_PROPERTIES
+      desc: $x_rtas_builder_exp_properties_t
+      version: "1.7"
+      value: "0x00020010"
+    - name: RTAS_PARALLEL_OPERATION_EXP_PROPERTIES
+      desc: $x_rtas_parallel_operation_exp_properties_t
+      version: "1.7"
+      value: "0x00020011"
+    - name: RTAS_DEVICE_EXP_PROPERTIES
+      desc: $x_rtas_device_exp_properties_t
+      version: "1.7"
+      value: "0x00020012"
+    - name: RTAS_GEOMETRY_AABBS_EXP_CB_PARAMS
+      desc: $x_rtas_geometry_aabbs_exp_cb_params_t
+      version: "1.7"
+      value: "0x00020013"
     - name: COMMAND_GRAPH_EXP_DESC
       desc: $x_command_graph_exp_desc_t
       version: "2.0"
@@ -542,6 +576,18 @@ members:
     - type: uint8_t
       name: "id[$X_MAX_UUID_SIZE]"
       desc: "[out] opaque data representing a UUID"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Base for all callback function parameter types"
+name: $x_base_cb_params_t
+members:
+    - type: $x_structure_type_t
+      name: stype
+      desc: "[in] type of this structure"
+    - type: "void*"
+      name: pNext
+      desc: "[in,out][optional] must be null or a pointer to an extension-specific structure (i.e. contains sType and pNext)."
+      init: nullptr
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -586,7 +586,7 @@ members:
       desc: "[in] type of this structure"
     - type: "void*"
       name: pNext
-      desc: "[in,out][optional] must be null or a pointer to an extension-specific structure (i.e. contains sType and pNext)."
+      desc: "[in,out][optional] must be null or a pointer to an extension-specific structure (i.e. contains stype and pNext)."
       init: nullptr
 --- #--------------------------------------------------------------------------
 type: struct

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -229,6 +229,7 @@ def _validate_doc(f, d, tags, line_num):
         valid_names = [
             "%s_base_desc_t"%namespace,
             "%s_base_properties_t"%namespace,
+            "%s_base_cb_params_t"%namespace,
             "%s_driver_extension_properties_t"%namespace
             ]
         if d['name'] not in valid_names:
@@ -237,6 +238,9 @@ def _validate_doc(f, d, tags, line_num):
 
             elif type_traits.is_properties(d['name']) and not d.get('base', "").endswith("base_properties_t"):
                 raise Exception("'base' must be '%s_base_properties_t': %s"%(namespace, d['name']))
+
+            elif type_traits.is_cb_params(d['name']) and not d.get('base', "").endswith("base_cb_params_t"):
+                raise Exception("'base' must be '%s_base_cb_params_t': %s"%(namespace, d['name']))
 
     def __validate_members(d, tags):
         if 'members' not in d:

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -71,6 +71,13 @@ extern "C" {
 ## TYPEDEF ####################################################################
 %elif re.match(r"typedef", obj['type']):
 typedef ${th.subt(n, tags, obj['value'])} ${th.make_type_name(n, tags, obj)};
+## CALLBACK ####################################################################
+%elif re.match(r"callback", obj['type']):
+typedef ${th.subt(n, tags, obj['returntype'])} (*${th.subt(n, tags, obj['name'])})(
+        %for line in th.make_param_lines(n, tags, obj):
+        ${line}
+        %endfor
+    );
 ## ENUM #######################################################################
 %elif re.match(r"enum", obj['type']):
 %if th.type_traits.is_flags(obj['name']):

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -91,6 +91,7 @@ class type_traits:
     RE_POINTER  = r"(.*\w+)\*+"
     RE_DESC     = r"(.*)desc_t.*"
     RE_PROPS    = r"(.*)properties_t.*"
+    RE_PARAMS   = r"(.*)cb_params_t.*"
     RE_FLAGS    = r"(.*)flags_t"
 
     @staticmethod
@@ -137,6 +138,13 @@ class type_traits:
     def is_properties(cls, name):
         try:
             return True if re.match(cls.RE_PROPS, name) else False
+        except:
+            return False
+
+    @classmethod
+    def is_cb_params(cls, name):
+        try:
+            return True if re.match(cls.RE_PARAMS, name) else False
         except:
             return False
 
@@ -385,7 +393,7 @@ class function_traits:
 
 """
 Public:
-    substitues each tag['key'] with tag['value']
+    substitutes each tag['key'] with tag['value']
     if comment, then insert doxygen '::' notation at beginning (for autogen links)
 """
 def subt(namespace, tags, string, comment=False, remove_namespace=False):

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -11,7 +11,7 @@ exhale==0.3.0
 idna==2.8
 imagesize==1.1.0
 Jinja2==2.10.3
-lxml==4.9.1
+lxml==4.9.2
 Mako==1.1.0
 MarkupSafe==1.1.1
 packaging==19.2


### PR DESCRIPTION
This extension provides the functionality to build ray tracing acceleration structures for 3D scenes on the host for use with GPU devices.

Resolves #146 