### PR TITLE
Some fixes for kernel max group size extension

### DIFF
--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -419,6 +419,9 @@ etors:
     - name: EVENT_QUERY_KERNEL_TIMESTAMPS_RESULTS_EXT_PROPERTIES
       desc: $x_event_query_kernel_timestamps_results_ext_properties_t
       version: "1.6"
+    - name: KERNEL_MAX_GROUP_SIZE_EXT_PROPERTIES
+      desc: $x_kernel_max_group_size_ext_properties_t
+      version: "1.7"
     - name: RELAXED_ALLOCATION_LIMITS_EXP_DESC
       desc: $x_relaxed_allocation_limits_exp_desc_t
       value: "0x00020001"

--- a/scripts/core/kernelMaxGroupSizeProperties.yml
+++ b/scripts/core/kernelMaxGroupSizeProperties.yml
@@ -37,3 +37,9 @@ members:
       desc: "[out] maximum group size that can be used to execute the kernel. This value may be less than or equal to the `maxTotalGroupSize` member of $x_device_compute_properties_t."
 details:
     - "This structure may be passed to $xKernelGetProperties, via the `pNext` member of $x_kernel_properties_t, to query additional kernel max group size properties."
+--- #--------------------------------------------------------------------------
+type: typedef
+desc: "compiler-independent type"
+name: $x_kernel_max_group_size_ext_properties_t
+version: "1.7"
+value: $x_kernel_max_group_size_properties_ext_t


### PR DESCRIPTION
- Added stype.
- Defined alias since original name didnt follow convention.

Resolves: #156