### PR TITLE
Fix ZET typo to conform to naming convention.

### DIFF
--- a/scripts/tools/common.yml
+++ b/scripts/tools/common.yml
@@ -109,8 +109,15 @@ etors:
       desc: $t_tracer_exp_desc_t
       value: "0x00010001"
     - name: METRICS_CALCULATE_EXP_DESC
-      desc: $t_metric_calculate_exp_desc_t
+      desc:
+            "1.6": $t_metric_calculate_exp_desc_t
+            "1.7": $t_metric_calculate_exp_desc_t. Deprecated, use $T_STRUCTURE_TYPE_METRIC_CALCULATE_EXP_DESC.
       version: "1.6"
+      value: "0x00010002"
+    - name: METRIC_CALCULATE_EXP_DESC
+      desc: $t_metric_calculate_exp_desc_t
+      version: "1.7"
+      value: "0x00010002"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"

--- a/scripts/tools/common.yml
+++ b/scripts/tools/common.yml
@@ -103,8 +103,15 @@ etors:
     - name: DEBUG_REGSET_PROPERTIES
       desc: $t_debug_regset_properties_t
     - name: GLOBAL_METRICS_TIMESTAMPS_EXP_PROPERTIES
-      desc: $t_metric_global_timestamps_resolution_exp_t
+      desc:
+            "1.5": $t_metric_global_timestamps_resolution_exp_t
+            "1.7": $t_metric_global_timestamps_resolution_exp_t. Deprecated, use $T_STRUCTURE_TYPE_METRIC_GLOBAL_TIMESTAMPS_RESOLUTION_EXP.
       version: "1.5"
+      value: "0x9"
+    - name: METRIC_GLOBAL_TIMESTAMPS_RESOLUTION_EXP
+      desc: $t_metric_global_timestamps_resolution_exp_t
+      version: "1.7"
+      value: "0x9"
     - name: TRACER_EXP_DESC
       desc: $t_tracer_exp_desc_t
       value: "0x00010001"


### PR DESCRIPTION
- Add ZET_STRUCTURE_TYPE_METRIC_CALCULATE_EXP_DESC
- Add ZET_STRUCTURE_TYPE_METRIC_GLOBAL_TIMESTAMPS_RESOLUTION_EXP
- Deprecate ZET_STRUCTURE_TYPE_METRICS_CALCULATE_EXP_DESC
- Deprecate ZET_STRUCTURE_TYPE_GLOBAL_METRICS_TIMESTAMPS_EXP_PROPERTIES

Resolves #157 
Resolves #158 