### PR TITLE
Minor fix to kernel timestamp example in programming guide.

### DIFF
--- a/scripts/core/PROG.rst
+++ b/scripts/core/PROG.rst
@@ -1102,7 +1102,7 @@ A kernel timestamp event is a special type of event that records device timestam
 %if ver < 1.1:
        const uint64_t timestampFreq = device_properties.timerResolution;
 %endif
-       const uint64_t timestampMaxValue = ~(-1 << device_properties.kernelTimestampValidBits);
+       const uint64_t timestampMaxValue = ~(-1L << device_properties.kernelTimestampValidBits);
 
        // Create event pool
        ${x}_event_pool_desc_t tsEventPoolDesc = {


### PR DESCRIPTION
Resolves #136