### PR TITLE
Add correctly callbacks definitions to headers

### DIFF
--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -988,7 +988,7 @@ Public:
 def get_pfncbtables(specs, meta, namespace, tags):
     tables = []
     for cname in sorted(meta['class'], key=lambda x: meta['class'][x]['ordinal']):
-        objs = get_class_function_objs(specs, cname, 1.0)
+        objs = get_class_function_objs(specs, cname)
         if len(objs) > 0:
             name = get_table_name(namespace, tags, {'class': cname})
             table = "%s_%s_callbacks_t"%(namespace, _camel_to_snake(name))


### PR DESCRIPTION
Callbacks for functions declared for a specific version were not being added to ze_api.h, forcing us to have them defined in include/layers/zel_tracing_register_cb.h, which is not correct.

So fix it so all are added to ze_api.h. by the time execution reaches the line being fixed here, versioning has already been taken into account, so only the functions for a specific version have been defined.