### PR TITLE
Add new GPU power domain

### DIFF
--- a/scripts/sysman/power.yml
+++ b/scripts/sysman/power.yml
@@ -27,6 +27,9 @@ etors:
     - name: MEMORY
       desc: "The PUnit power domain is a memory-level power domain."
       version: "1.8"
+    - name: GPU
+      desc: "The PUnit power domain is a GPU-level power domain."
+      version: "1.8"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Power Level Type"


### PR DESCRIPTION
CARD domain is technically for whole PCI card which might include more than just the GPU IP. So, adding separate GPU domain helps to provide GPU specific power related info.

Addresses: #223