### PR TITLE
[EXT_EXP_BindlessImages] Create sampled image from a sampler object

### DIFF
--- a/scripts/core/EXT_EXP_BindlessImages.rst
+++ b/scripts/core/EXT_EXP_BindlessImages.rst
@@ -27,6 +27,7 @@ API
     * ${x}_device_pitched_alloc_exp_properties_t
     * ${x}_image_bindless_exp_desc_t
     * ${x}_image_pitched_exp_desc_t
+    * ${x}_sampler_ptr_exp_desc_t
 
 * Functions
 
@@ -46,7 +47,8 @@ This function only allows for the allocation of image memory in an implementatio
 In this extension, we propose the following additions:
  * Provide a new image descriptor and flags for Bindless images.
  * Support for creation of images on linearly allocated memory backed by USM.
- * Extension API to create an image handle from pitched memory
+ * Extension API to create an image handle from pitched memory.
+ * Create sampled image from the new image descriptor and a sampler.
 
 A "Bindless image" can be created by passing ${x}_image_bindless_exp_desc_t to pNext member of
 ${x}_image_desc_t and set the flags value as ${X}_IMAGE_BINDLESS_EXP_FLAG_BINDLESS

--- a/scripts/core/bindlessimages.yml
+++ b/scripts/core/bindlessimages.yml
@@ -65,6 +65,19 @@ members:
       init: "0"
 --- #--------------------------------------------------------------------------
 type: struct
+desc: "Sampler created from $xSamplerCreate. This structure may be passed to $xImageCreate via pNext member of $x_image_desc_t, $x_image_pitched_exp_desc_t or $x_image_bindless_exp_desc_t."
+class: $xImage
+version: "1.9"
+name: $x_sampler_exp_desc_t
+base: $x_base_desc_t
+members:
+    - type: void*
+      name: sampler
+      desc: |
+            [in] handle of a sampler
+      init: "0"
+--- #--------------------------------------------------------------------------
+type: struct
 desc: "Device specific properties for pitched allocations"
 version: "1.9"
 class: $xDevice

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -556,6 +556,10 @@ etors:
       desc: $x_image_pitched_exp_desc_t
       version: "1.9"
       value: "0x0002001F"
+    - name: SAMPLER_EXP_DESC
+      desc: $x_sampler_exp_desc_t
+      version: "1.9"
+      value: "0x00020020"
     - name: COMMAND_GRAPH_EXP_DESC
       desc: $x_command_graph_exp_desc_t
       version: "2.0"


### PR DESCRIPTION
Add a new descriptor ze_sampler_exp_desc_t that contains a pointer to sampler object. A bindless sampled image could be created by passing the new descriptor via pNext member using zeImageCreate API. Motivation is to support a single 64-bit handle for SYCL bindless sampled image.