### PR TITLE
Fix typo in for `device property`

### DIFF
--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -153,7 +153,7 @@ members:
     - type: uint32_t
       name: deviceId
       desc: |
-            [out] device id from PCI configuration
+            [out] device id from PCI configuration.
             Note, the device id uses little-endian format.
     - type: $x_device_property_flags_t
       name: flags


### PR DESCRIPTION
https://spec.oneapi.io/level-zero/latest/core/api.html#structze__device__properties__t

```
uint32_t deviceId
    [out] device id from PCI configuration Note, the device id uses little-endian format.
```
Missing a `.` before Note. 