### PR TITLE
Add ZE_API_VERSION_CURRENT_M macro

### DIFF
--- a/scripts/core/driver.yml
+++ b/scripts/core/driver.yml
@@ -116,6 +116,11 @@ etors:
       desc: "version 1.9"
       version: "1.9"
 --- #--------------------------------------------------------------------------
+type: macro
+desc: "Current API version as a macro"
+name: "$X_API_VERSION_CURRENT_M"
+value: "$X_MAKE_VERSION( 1, 9 )"
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Returns the API version supported by the specified driver"
 class: $xDriver


### PR DESCRIPTION
This enables preprocessor level API version checks, which can be used to guard code that requires a specific version of the API. For example:

```c++
#ifdef ZE_API_VERSION_CURRENT_M
#if ZE_API_VERSION_CURRENT_M >= ZE_MAKE_VERSION(1, 9)

namespace {
  // test content
}

#endif
#endif
```

Our specific use case is the L0 conformance tests repository. Every time tests of newly released features are added, backwards compatibility with older loader releases is broken. Our users can't always choose which version of the loader they have installed, so our goal is to be able to support all loader releases at least back to v1.15 (spec API 1.8).